### PR TITLE
Provider-side diff calculation

### DIFF
--- a/examples/appservice/index.ts
+++ b/examples/appservice/index.ts
@@ -3,7 +3,7 @@ import * as azurerm from "../../sdk/nodejs";
 
 const resourceGroup = new azurerm.core.ResourceGroup("rg", {
     name: "azurerm-appservice",
-    location: "westeurope",
+    location: "westus2",
     tags: {
         Owner: "mikhailshilkov",
         Env: "prod2",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
-	github.com/go-openapi/jsonpointer v0.19.3
 	github.com/go-openapi/spec v0.19.7
 	github.com/go-openapi/swag v0.19.9
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/pkg/provider/diff.go
+++ b/pkg/provider/diff.go
@@ -1,0 +1,182 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-azurerm/pkg/openapi"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	rpc "github.com/pulumi/pulumi/sdk/v2/proto/go"
+	"strings"
+)
+
+// calculateDetailedDiff produced a property diff for a given diff and a resource definition. It inspects the schema
+// of the resource to find out if the requested diff can be performed in-place or requires a replacement.
+func calculateDetailedDiff(resource Resource, diff *resource.ObjectDiff) (map[string]*rpc.PropertyDiff, error) {
+	spec, err := openapi.NewSpec(resource.swagggerSpecLocation)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load spec %s", resource.swagggerSpecLocation)
+	}
+	path := spec.Paths.Paths[resource.path]
+
+	// If a property is a part of the PATCH payload, we consider it mutable.
+	var patchSchema *openapi.Schema
+	if path.Patch != nil {
+		for _, param := range path.Patch.Parameters {
+			if param.In == "body" {
+				param, err := spec.ResolveParameter(param)
+				if err != nil {
+					return nil, err
+				}
+
+				if param.Schema == nil {
+					break
+				}
+
+				patchSchema, err = param.ResolveSchema(param.Schema)
+				if err != nil {
+					return nil, err
+				}
+				break
+			}
+		}
+	}
+
+	d := differ { patchSchema: patchSchema}
+	return d.calculateDetailedDiff(diff, "")
+}
+
+type differ struct {
+	patchSchema *openapi.Schema
+}
+
+func (d *differ) calculateDetailedDiff(diff *resource.ObjectDiff, base string) (map[string]*rpc.PropertyDiff, error) {
+	detailedDiff := map[string]*rpc.PropertyDiff{}
+	for k, v := range diff.Updates {
+		key := base + string(k)
+		if v.Object == nil {
+			kind := rpc.PropertyDiff_UPDATE_REPLACE
+			pb, err := d.isPatchable(key)
+			if err != nil {
+				return nil, err
+			}
+
+			if pb {
+				kind = rpc.PropertyDiff_UPDATE
+			}
+			detailedDiff[key] = &rpc.PropertyDiff{Kind: kind}
+		} else {
+			subDiff, err := d.calculateDetailedDiff(v.Object, key + ".")
+			if err != nil {
+				return nil, err
+			}
+
+			for sk, sv := range subDiff {
+				detailedDiff[sk] = sv
+			}
+		}
+	}
+	for k, _ := range diff.Adds {
+		key := base + string(k)
+		kind := rpc.PropertyDiff_ADD_REPLACE
+		pb, err := d.isPatchable(key)
+		if err != nil {
+			return nil, err
+		}
+
+		if pb {
+			kind = rpc.PropertyDiff_ADD
+		}
+		detailedDiff[key] = &rpc.PropertyDiff{Kind: kind}
+	}
+	for k, _ := range diff.Deletes {
+		key := base + string(k)
+		kind := rpc.PropertyDiff_DELETE_REPLACE
+		pb, err := d.isPatchable(key)
+		if err != nil {
+			return nil, err
+		}
+
+		if pb {
+			kind = rpc.PropertyDiff_DELETE
+		}
+		detailedDiff[key] = &rpc.PropertyDiff{Kind: kind}
+	}
+
+	return detailedDiff, nil
+}
+
+// isPatchable checks if a property with a given name belongs to the PATCH method payload.
+func (d *differ) isPatchable(name string) (bool, error) {
+	return d.existsInSchema(name, d.patchSchema)
+}
+
+// existsInSchema checks whether a property with the given path (e.g. `foo.bar`) exists in the given schema.
+func (d *differ) existsInSchema(propertyPath string, schema *openapi.Schema) (bool, error) {
+	if schema == nil {
+		return false, nil
+	}
+
+	parts := strings.Split(propertyPath, ".")
+
+	for k, v := range schema.Properties {
+		if k == parts[0] {
+			// If the path has no dots in it, we found the match.
+			if len(parts) == 1 {
+				return true, nil
+			}
+
+			// Otherwise, resolve the child schema.
+			propertySchema, err := schema.ResolveSchema(&v)
+			if err != nil {
+				return false, err
+			}
+
+			// If child schema is not an object with properties (e.g. we are looking at a dictionary of tags),
+			// we found the match.
+			if len(propertySchema.Properties) == 0 {
+				return true, nil
+			}
+
+			// Inspect the child properties recursively.
+			newPath := strings.Join(parts[1:], ".")
+			subPatchable, err := d.existsInSchema(newPath, propertySchema)
+			if err != nil {
+				return false, err
+			}
+
+			return subPatchable, nil
+		}
+	}
+
+	// If the main schema doesn't contain the target property, check if it's in AllOf schemas.
+	for _, s := range schema.AllOf {
+		allOfSchema, err := schema.ResolveSchema(&s)
+		if err != nil {
+			return false, err
+		}
+
+		basePatchable, err := d.existsInSchema(propertyPath, allOfSchema)
+		if err != nil {
+			return false, err
+		}
+
+		if basePatchable {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -139,14 +139,83 @@ func (k *azurermProvider) DiffConfig(ctx context.Context, req *rpc.DiffRequest) 
 
 // Diff checks what impacts a hypothetical update will have on the resource's properties.
 func (k *azurermProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
-	// TODO: Actually figure out whether any properties require replacement
-	// * Anything that goes in `path` requies replacement
-	return &rpc.DiffResponse{
-		Changes:             0,
-		Replaces:            []string{},
+	urn := resource.URN(req.GetUrn())
+	label := fmt.Sprintf("%s.Diff(%s)", k.name, urn)
+
+	// Retrieve the old state.
+	oldState, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{
+		Label: fmt.Sprintf("%s.olds", label), KeepUnknowns: true, SkipNulls: true, KeepSecrets: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract old inputs from the `__inputs` field of the old state.
+	oldInputs := parseCheckpointObject(oldState)
+
+	// Get new resource inputs. The user is submitting these as an update.
+	newResInputs, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
+		Label:        fmt.Sprintf("%s.news", label),
+		KeepUnknowns: true,
+		SkipNulls:    true,
+		RejectAssets: true,
+		KeepSecrets:  true,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "diff failed because malformed resource inputs %v %v", oldState, newResInputs)
+	}
+
+	// Calculate the difference between old and new inputs.
+	diff := oldInputs.Diff(newResInputs)
+
+	if diff == nil {
+		return &rpc.DiffResponse{
+			Changes:             0,
+			Replaces:            []string{},
+			Stables:             []string{},
+			DeleteBeforeReplace: false,
+		}, nil
+	}
+
+	resourceKey := string(urn.Type())
+	resource, ok := k.resourceMap[resourceKey]
+	if !ok {
+		return nil, errors.Errorf("Resource type %s not found", resourceKey)
+	}
+
+	// Calculate the detailed diff object containing information about replacements.
+	detailedDiff, err := calculateDetailedDiff(resource, diff)
+	if err != nil {
+		return nil, errors.Wrap(err, "calculating detailed diff")
+	}
+
+	// Based on the detailed diff above, calculate the list of changes and replacements.
+	var changes, replaces []string
+	for k, v := range detailedDiff {
+		parts := strings.Split(k, ".")
+		changes = append(changes, parts[0])
+		v.InputDiff = true
+
+		switch v.Kind {
+		case rpc.PropertyDiff_ADD_REPLACE, rpc.PropertyDiff_DELETE_REPLACE, rpc.PropertyDiff_UPDATE_REPLACE:
+			replaces = append(replaces, k)
+		}
+	}
+
+	// TODO: Define delete-before-replace only if autonaming is off.
+	deleteBeforeReplace := len(replaces) > 0
+
+	response := rpc.DiffResponse{
+		Changes:             rpc.DiffResponse_DIFF_SOME,
+		Replaces:            replaces,
 		Stables:             []string{},
-		DeleteBeforeReplace: false,
-	}, nil
+		DeleteBeforeReplace: deleteBeforeReplace,
+		Diffs:               changes,
+		DetailedDiff:        detailedDiff,
+		HasDetailedDiff:     true,
+	}
+
+	return &response, nil
 }
 
 // Create allocates a new instance of the provided resource and returns its unique ID afterwards.
@@ -204,17 +273,20 @@ func (k *azurermProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*
 		return nil, err
 	}
 
+	// Store both outputs and inputs into the state.
+	obj := checkpointObject(inputs, outputs)
+
 	// Serialize and return RPC outputs
-	outputProperties, err := plugin.MarshalProperties(
-		resource.NewPropertyMapFromMap(outputs),
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.autonamedInputs", label), KeepUnknowns: true, SkipNulls: true},
+	checkpoint, err := plugin.MarshalProperties(
+		obj,
+		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepUnknowns: true, SkipNulls: true},
 	)
 	if err != nil {
 		return nil, err
 	}
 	return &rpc.CreateResponse{
 		Id:         id,
-		Properties: outputProperties,
+		Properties: checkpoint,
 	}, nil
 }
 
@@ -224,19 +296,36 @@ func (k *azurermProvider) Read(ctx context.Context, req *rpc.ReadRequest) (*rpc.
 	label := fmt.Sprintf("%s.Read(%s)", k.name, urn)
 	glog.V(9).Infof("%s executing", label)
 	id := req.GetId()
+
+	// Retrieve the old state.
+	oldState, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{
+		Label: fmt.Sprintf("%s.olds", label), KeepUnknowns: true, SkipNulls: true, KeepSecrets: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract old inputs from the `__inputs` field of the old state.
+	inputs := parseCheckpointObject(oldState)
+
 	res := k.resourceMap[string(urn.Type())]
 	outputs, err := k.azureGet(ctx, id, res.apiVersion)
 	if err != nil {
 		return nil, err
 	}
-	outputProperties, err := plugin.MarshalProperties(
-		resource.NewPropertyMapFromMap(outputs),
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.autonamedInputs", label), KeepUnknowns: true, SkipNulls: true},
+
+	// Store both outputs and inputs into the state.
+	obj := checkpointObject(inputs, outputs)
+
+	// Serialize and return RPC outputs.
+	checkpoint, err := plugin.MarshalProperties(
+		obj,
+		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepUnknowns: true, SkipNulls: true},
 	)
 	if err != nil {
 		return nil, err
 	}
-	return &rpc.ReadResponse{Id: id, Properties: outputProperties}, nil
+	return &rpc.ReadResponse{Id: id, Properties: checkpoint}, nil
 }
 
 // Update updates an existing resource with new values.
@@ -270,15 +359,19 @@ func (k *azurermProvider) Update(ctx context.Context, req *rpc.UpdateRequest) (*
 		return nil, err
 	}
 
-	outputProperties, err := plugin.MarshalProperties(
-		resource.NewPropertyMapFromMap(outputs),
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.autonamedInputs", label), KeepUnknowns: true, SkipNulls: true},
+	// Store both outputs and inputs into the state.
+	obj := checkpointObject(inputs, outputs)
+
+	// Serialize and return RPC outputs.
+	checkpoint, err := plugin.MarshalProperties(
+		obj,
+		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepUnknowns: true, SkipNulls: true},
 	)
 	if err != nil {
 		return nil, err
 	}
 	return &rpc.UpdateResponse{
-		Properties: outputProperties,
+		Properties: checkpoint,
 	}, nil
 }
 
@@ -578,4 +671,18 @@ func nameParameter(path string) string {
 		}
 	}
 	return ""
+}
+
+// checkpointObject puts inputs in the `__inputs` field of the state.
+func checkpointObject(inputs resource.PropertyMap, outputs map[string]interface{}) resource.PropertyMap {
+	object := resource.NewPropertyMapFromMap(outputs)
+	object["__inputs"] = resource.NewObjectProperty(inputs)
+	return object
+
+}
+
+// parseCheckpointObject returns inputs that are saved in the `__inputs` field of the state.
+func parseCheckpointObject(obj resource.PropertyMap) resource.PropertyMap {
+	inputs := obj["__inputs"]
+	return inputs.ObjectValue()
 }


### PR DESCRIPTION
- Stores inputs as a special `__inputs` field of the state (similar to k8s)
- Runs the provider-side diffs including the detailed diff
- Marks any diff as a replacement unless the corresponding property is a part of the PATCH method payload for the given resource (note that we still actually use PUT; PATCH is only for metadata)

Resolves #5
Opening to another PR branch to simplify the diff.