### PR TITLE
Use 'name' for all resource names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,4 @@ generate::
 	echo "Finished generating Schema & SDK."
 	cd ${PACKDIR}/nodejs/ && \
 		sed -i.bak "s/\$${VERSION}/$(VERSION)/g" ./package.json && \
-		yarn link @pulumi/pulumi
+		yarn install

--- a/examples/appservice/index.ts
+++ b/examples/appservice/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as azurerm from "../../sdk/nodejs";
 
 const resourceGroup = new azurerm.core.ResourceGroup("rg", {
-    resourceGroupName: "azurerm-appservice",
+    name: "azurerm-appservice",
     location: "westus2",
     tags: {
         Owner: "mikhailshilkov",
@@ -12,7 +12,7 @@ const resourceGroup = new azurerm.core.ResourceGroup("rg", {
 
 const storageAccount = new azurerm.storage.StorageAccount("sa", {
     resourceGroupName: resourceGroup.name,
-    accountName: "pulumiassa",
+    name: "pulumiassa",
     location: "westus2",
     sku: {
         name: "Standard_LRS",
@@ -35,7 +35,7 @@ const appServicePlan  = new azurerm.web.AppServicePlan("asp", {
 const storageContainer = new azurerm.storage.StorageAccountBlobServiceContainer("c", {
     resourceGroupName: resourceGroup.name,
     accountName: storageAccount.name,
-    containerName: "files",
+    name: "files",
     properties: {
         publicAccess: "none",
     },
@@ -56,7 +56,7 @@ const storageContainer = new azurerm.storage.StorageAccountBlobServiceContainer(
 const appInsights = new azurerm.insights.Component("ai", {
     resourceGroupName: resourceGroup.name,
     location: "westus2",
-    resourceName: "pulumi-as-ai",
+    name: "pulumi-as-ai",
     kind: "web",
     properties: {
         Application_Type: "web",
@@ -69,7 +69,7 @@ const pwd = "Not2S3cure!?";
 const sqlServer = new azurerm.sql.Server("sql", {
     resourceGroupName: resourceGroup.name,
     location: "westus2",
-    serverName: "pulumi-as-sql",
+    name: "pulumi-as-sql",
     properties: {
         administratorLogin: username,
         administratorLoginPassword: pwd,
@@ -81,7 +81,7 @@ const database = new azurerm.sql.ServerDatabase("db", {
     resourceGroupName: resourceGroup.name,
     location: "westus2",
     serverName: sqlServer.name,
-    databaseName: "db",
+    name: "db",
     properties: {
         requestedServiceObjectiveName: "S0",
     }

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as azurerm from "../../sdk/nodejs";
 
 const resourceGroup = new azurerm.core.ResourceGroup("rg", {
-    resourceGroupName: "azurerm",
+    name: "azurerm",
     location: "westus2",
     tags: {
         Owner: "mikhailshilkov",
@@ -36,7 +36,7 @@ export const staticWebsiteUrl = pulumi.interpolate`https://${staticSite.properti
 const containerinstance = new azurerm.containerinstance.ContainerGroup("containergroup", {
     resourceGroupName: resourceGroup.name,
     // should be autonamed?
-    containerGroupName: "abc-1234",
+    name: "abc-1234",
     location: "westus2",
     // should be inlined via 'x-ms-client-flatten'
     properties: {
@@ -59,7 +59,7 @@ const containerinstance = new azurerm.containerinstance.ContainerGroup("containe
 
 const vnet = new azurerm.network.VirtualNetwork("vnet", {
     resourceGroupName: resourceGroup.name,
-    virtualNetworkName: "vnet-1234",
+    name: "vnet-1234",
     location: "westus2",
     properties: {
         addressSpace: {
@@ -85,7 +85,7 @@ const subnet = new azurerm.network.VirtualNetworkSubnet("subnet2", {
 
 const networkInterface = new azurerm.network.NetworkInterface("nic", {
     resourceGroupName: resourceGroup.name,
-    networkInterfaceName: "nic-1234",
+    name: "nic-1234",
     location: "westus2",
     properties: {
         ipConfigurations: [{
@@ -102,7 +102,7 @@ const networkInterface = new azurerm.network.NetworkInterface("nic", {
 
 const virtualmachine  = new azurerm.compute.VirtualMachine("vm", {
     resourceGroupName: resourceGroup.name,
-    vmName: "abc-1234",
+    name: "abc-1234",
     location: "westus2",
     properties: {
         hardwareProfile: {
@@ -151,7 +151,7 @@ const appService = new azurerm.web.AppService("app", {
 
 const storageAccount = new azurerm.storage.StorageAccount("sa", {
     resourceGroupName: resourceGroup.name,
-    accountName: "pulumi14345sa",
+    name: "pulumi14345sa",
     location: "westus2",
     sku: {
         name: "Standard_LRS",

--- a/examples/static-website/index.ts
+++ b/examples/static-website/index.ts
@@ -3,7 +3,7 @@ import * as azurerm from "../../sdk/nodejs";
 import { URL } from "url";
 
 const resourceGroup = new azurerm.core.ResourceGroup("rg", {
-    resourceGroupName: "azurerm-static-website",
+    name: "azurerm-static-website",
     location: "westus2",
     tags: {
         Owner: "mikhailshilkov",
@@ -14,7 +14,7 @@ const resourceGroup = new azurerm.core.ResourceGroup("rg", {
 // Create a Storage Account for our static website
 const storageAccount = new azurerm.storage.StorageAccount("websitesa", {
     resourceGroupName: resourceGroup.name,
-    accountName: "pulumiswsa",
+    name: "pulumiswsa",
     location: "westus2",
     sku: {
         name: "Standard_LRS",
@@ -50,7 +50,7 @@ const staticHostname = staticEndpoint.apply(url => url && new URL(url).hostname)
 // We can add a CDN in front of the website
 const cdn =  new azurerm.cdn.Profile("website-cdn", {
     resourceGroupName: resourceGroup.name,
-    profileName: "pulumi-static-website",
+    name: "pulumi-static-website",
     location: "global",
     sku: {
           name: "Standard_Microsoft",
@@ -60,7 +60,7 @@ const cdn =  new azurerm.cdn.Profile("website-cdn", {
 const endpoint = new azurerm.cdn.ProfileEndpoint("website-cdn-ep", {
     resourceGroupName: resourceGroup.name,
     profileName: cdn.name,
-    endpointName: "pulumi-static-website-ep",
+    name: "pulumi-static-website-ep",
     location: "westus",
     properties: {
         originHostHeader: staticHostname,

--- a/examples/template/index.ts
+++ b/examples/template/index.ts
@@ -42,34 +42,24 @@ class Template extends pulumi.ComponentResource {
             let typeName;
             if (resource.type === "Microsoft.Compute/virtualMachines") {
                 typeName = "azurerm:compute:VirtualMachine";
-                resourceArgs.vmName = resource.name;
             } else if (resource.type === "Microsoft.Network/networkInterfaces") {
                 typeName = "azurerm:network:NetworkInterface";
-                resourceArgs.networkInterfaceName = resource.name;
             } else if (resource.type === "Microsoft.Network/networkSecurityGroups") {
                 typeName = "azurerm:network:NetworkSecurityGroup";
-                resourceArgs.networkSecurityGroupName = resource.name;
             } else if (resource.type === "Microsoft.Network/publicIPAddresses") {
                 typeName = "azurerm:network:PublicIPAddress";
-                resourceArgs.publicIpAddressName = resource.name;
             } else if (resource.type === "Microsoft.Network/virtualNetworks") {
                 typeName = "azurerm:network:VirtualNetwork";
-                resourceArgs.virtualNetworkName = resource.name;
             } else if (resource.type === "Microsoft.Storage/storageAccounts") {
                 typeName = "azurerm:storage:StorageAccount";
-                resourceArgs.accountName = resource.name;
             } else if (resource.type === "Microsoft.Web/serverfarms") {
                 typeName = "azurerm:web:AppServicePlan";
-                resourceArgs.name = resource.name;
             } else if (resource.type === "Microsoft.Web/sites") {
                 typeName = "azurerm:web:AppService";
-                resourceArgs.name = resource.name;
             } else if (resource.type === "Microsoft.Cache/Redis") {
                 typeName = "azurerm:cache:Redis";
-                resourceArgs.name = resource.name;                
             } else if (resource.type === "Microsoft.ContainerInstance/containerGroups") {
                 typeName = "azurerm:containerinstance:ContainerGroup";
-                resourceArgs.containerGroupName = resource.name;                
             } else {
                 throw new Error(`Unknown type ${resource.type}`);
             }
@@ -82,7 +72,7 @@ class Template extends pulumi.ComponentResource {
 const resourceGroupName = "azurermtemplates";
 
 const resourceGroup = new ResourceGroup("azurerm", {
-    resourceGroupName,
+    name: resourceGroupName,
     location: "westus2",
     tags: {
         Owner: "mikhailshilkov",

--- a/sdk/nodejs/cache/redisFirewallRule.ts
+++ b/sdk/nodejs/cache/redisFirewallRule.ts
@@ -40,7 +40,7 @@ export class RedisFirewallRule extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * redis cache firewall rule properties
      */
@@ -70,20 +70,19 @@ export class RedisFirewallRule extends pulumi.CustomResource {
             if (!args || args.cacheName === undefined) {
                 throw new Error("Missing required property 'cacheName'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.properties === undefined) {
                 throw new Error("Missing required property 'properties'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            if (!args || args.ruleName === undefined) {
-                throw new Error("Missing required property 'ruleName'");
-            }
             inputs["cacheName"] = args ? args.cacheName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["ruleName"] = args ? args.ruleName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -124,6 +123,10 @@ export interface RedisFirewallRuleArgs {
      */
     readonly cacheName: pulumi.Input<string>;
     /**
+     * The name of the firewall rule.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Properties required to create a firewall rule .
      */
     readonly properties: pulumi.Input<inputs.cache.RedisFirewallRuleProperties>;
@@ -131,8 +134,4 @@ export interface RedisFirewallRuleArgs {
      * The name of the resource group.
      */
     readonly resourceGroupName: pulumi.Input<string>;
-    /**
-     * The name of the firewall rule.
-     */
-    readonly ruleName: pulumi.Input<string>;
 }

--- a/sdk/nodejs/cdn/profile.ts
+++ b/sdk/nodejs/cdn/profile.ts
@@ -44,7 +44,7 @@ export class Profile extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The JSON object that contains the properties required to create a profile.
      */
@@ -85,8 +85,8 @@ export class Profile extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
-            if (!args || args.profileName === undefined) {
-                throw new Error("Missing required property 'profileName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
@@ -95,12 +95,11 @@ export class Profile extends pulumi.CustomResource {
                 throw new Error("Missing required property 'sku'");
             }
             inputs["location"] = args ? args.location : undefined;
-            inputs["profileName"] = args ? args.profileName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["sku"] = args ? args.sku : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -155,7 +154,7 @@ export interface ProfileArgs {
     /**
      * Name of the CDN profile which is unique within the resource group.
      */
-    readonly profileName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * The JSON object that contains the properties required to create a profile.
      */

--- a/sdk/nodejs/cdn/profileEndpoint.ts
+++ b/sdk/nodejs/cdn/profileEndpoint.ts
@@ -44,7 +44,7 @@ export class ProfileEndpoint extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The JSON object that contains the properties required to create an endpoint.
      */
@@ -77,11 +77,11 @@ export class ProfileEndpoint extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ProfileEndpointArgs | undefined;
-            if (!args || args.endpointName === undefined) {
-                throw new Error("Missing required property 'endpointName'");
-            }
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.profileName === undefined) {
                 throw new Error("Missing required property 'profileName'");
@@ -89,13 +89,12 @@ export class ProfileEndpoint extends pulumi.CustomResource {
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            inputs["endpointName"] = args ? args.endpointName : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["profileName"] = args ? args.profileName : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -140,13 +139,13 @@ export interface ProfileEndpointState {
  */
 export interface ProfileEndpointArgs {
     /**
-     * Name of the endpoint under the profile which is unique globally.
-     */
-    readonly endpointName: pulumi.Input<string>;
-    /**
      * Resource location.
      */
     readonly location: pulumi.Input<string>;
+    /**
+     * Name of the endpoint under the profile which is unique globally.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * Name of the CDN profile which is unique within the resource group.
      */

--- a/sdk/nodejs/cdn/profileEndpointCustomDomain.ts
+++ b/sdk/nodejs/cdn/profileEndpointCustomDomain.ts
@@ -40,7 +40,7 @@ export class ProfileEndpointCustomDomain extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The JSON object that contains the properties of the custom domain to create.
      */
@@ -67,11 +67,11 @@ export class ProfileEndpointCustomDomain extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ProfileEndpointCustomDomainArgs | undefined;
-            if (!args || args.customDomainName === undefined) {
-                throw new Error("Missing required property 'customDomainName'");
-            }
             if (!args || args.endpointName === undefined) {
                 throw new Error("Missing required property 'endpointName'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.profileName === undefined) {
                 throw new Error("Missing required property 'profileName'");
@@ -79,12 +79,11 @@ export class ProfileEndpointCustomDomain extends pulumi.CustomResource {
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            inputs["customDomainName"] = args ? args.customDomainName : undefined;
             inputs["endpointName"] = args ? args.endpointName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["profileName"] = args ? args.profileName : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -121,13 +120,13 @@ export interface ProfileEndpointCustomDomainState {
  */
 export interface ProfileEndpointCustomDomainArgs {
     /**
-     * Name of the custom domain within an endpoint.
-     */
-    readonly customDomainName: pulumi.Input<string>;
-    /**
      * Name of the endpoint under the profile which is unique globally.
      */
     readonly endpointName: pulumi.Input<string>;
+    /**
+     * Name of the custom domain within an endpoint.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * Name of the CDN profile which is unique within the resource group.
      */

--- a/sdk/nodejs/cdn/profileEndpointOrigin.ts
+++ b/sdk/nodejs/cdn/profileEndpointOrigin.ts
@@ -44,7 +44,7 @@ export class ProfileEndpointOrigin extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The JSON object that contains the properties of the origin.
      */
@@ -83,8 +83,8 @@ export class ProfileEndpointOrigin extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
-            if (!args || args.originName === undefined) {
-                throw new Error("Missing required property 'originName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.profileName === undefined) {
                 throw new Error("Missing required property 'profileName'");
@@ -94,12 +94,11 @@ export class ProfileEndpointOrigin extends pulumi.CustomResource {
             }
             inputs["endpointName"] = args ? args.endpointName : undefined;
             inputs["location"] = args ? args.location : undefined;
-            inputs["originName"] = args ? args.originName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["profileName"] = args ? args.profileName : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -154,7 +153,7 @@ export interface ProfileEndpointOriginArgs {
     /**
      * Name of the origin that is unique within the endpoint.
      */
-    readonly originName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Name of the CDN profile which is unique within the resource group.
      */

--- a/sdk/nodejs/cdn/profileEndpointOriginGroup.ts
+++ b/sdk/nodejs/cdn/profileEndpointOriginGroup.ts
@@ -40,7 +40,7 @@ export class ProfileEndpointOriginGroup extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The JSON object that contains the properties of the origin group.
      */
@@ -70,8 +70,8 @@ export class ProfileEndpointOriginGroup extends pulumi.CustomResource {
             if (!args || args.endpointName === undefined) {
                 throw new Error("Missing required property 'endpointName'");
             }
-            if (!args || args.originGroupName === undefined) {
-                throw new Error("Missing required property 'originGroupName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.profileName === undefined) {
                 throw new Error("Missing required property 'profileName'");
@@ -80,11 +80,10 @@ export class ProfileEndpointOriginGroup extends pulumi.CustomResource {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["endpointName"] = args ? args.endpointName : undefined;
-            inputs["originGroupName"] = args ? args.originGroupName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["profileName"] = args ? args.profileName : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -127,7 +126,7 @@ export interface ProfileEndpointOriginGroupArgs {
     /**
      * Name of the origin group which is unique within the endpoint.
      */
-    readonly originGroupName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Name of the CDN profile which is unique within the resource group.
      */

--- a/sdk/nodejs/compute/availabilitySet.ts
+++ b/sdk/nodejs/compute/availabilitySet.ts
@@ -44,7 +44,7 @@ export class AvailabilitySet extends pulumi.CustomResource {
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The instance view of a resource.
      */
@@ -82,22 +82,21 @@ export class AvailabilitySet extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as AvailabilitySetArgs | undefined;
-            if (!args || args.availabilitySetName === undefined) {
-                throw new Error("Missing required property 'availabilitySetName'");
-            }
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            inputs["availabilitySetName"] = args ? args.availabilitySetName : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["sku"] = args ? args.sku : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -146,13 +145,13 @@ export interface AvailabilitySetState {
  */
 export interface AvailabilitySetArgs {
     /**
-     * The name of the availability set.
-     */
-    readonly availabilitySetName: pulumi.Input<string>;
-    /**
      * Resource location
      */
     readonly location: pulumi.Input<string>;
+    /**
+     * The name of the availability set.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * The instance view of a resource.
      */

--- a/sdk/nodejs/compute/image.ts
+++ b/sdk/nodejs/compute/image.ts
@@ -44,7 +44,7 @@ export class Image extends pulumi.CustomResource {
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Describes the properties of an Image.
      */
@@ -77,21 +77,20 @@ export class Image extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ImageArgs | undefined;
-            if (!args || args.imageName === undefined) {
-                throw new Error("Missing required property 'imageName'");
-            }
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            inputs["imageName"] = args ? args.imageName : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -136,13 +135,13 @@ export interface ImageState {
  */
 export interface ImageArgs {
     /**
-     * The name of the image.
-     */
-    readonly imageName: pulumi.Input<string>;
-    /**
      * Resource location
      */
     readonly location: pulumi.Input<string>;
+    /**
+     * The name of the image.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * Describes the properties of an Image.
      */

--- a/sdk/nodejs/compute/proximityPlacementGroup.ts
+++ b/sdk/nodejs/compute/proximityPlacementGroup.ts
@@ -44,7 +44,7 @@ export class ProximityPlacementGroup extends pulumi.CustomResource {
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Describes the properties of a Proximity Placement Group.
      */
@@ -80,18 +80,17 @@ export class ProximityPlacementGroup extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
-            if (!args || args.proximityPlacementGroupName === undefined) {
-                throw new Error("Missing required property 'proximityPlacementGroupName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
-            inputs["proximityPlacementGroupName"] = args ? args.proximityPlacementGroupName : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -140,13 +139,13 @@ export interface ProximityPlacementGroupArgs {
      */
     readonly location: pulumi.Input<string>;
     /**
+     * The name of the proximity placement group.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Describes the properties of a Proximity Placement Group.
      */
     readonly properties?: pulumi.Input<inputs.compute.ProximityPlacementGroupProperties>;
-    /**
-     * The name of the proximity placement group.
-     */
-    readonly proximityPlacementGroupName: pulumi.Input<string>;
     /**
      * The name of the resource group.
      */

--- a/sdk/nodejs/compute/virtualMachine.ts
+++ b/sdk/nodejs/compute/virtualMachine.ts
@@ -48,7 +48,7 @@ export class VirtualMachine extends pulumi.CustomResource {
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
      */
@@ -100,21 +100,20 @@ export class VirtualMachine extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            if (!args || args.vmName === undefined) {
-                throw new Error("Missing required property 'vmName'");
-            }
             inputs["identity"] = args ? args.identity : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["plan"] = args ? args.plan : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["vmName"] = args ? args.vmName : undefined;
             inputs["zones"] = args ? args.zones : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["resources"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
@@ -184,6 +183,10 @@ export interface VirtualMachineArgs {
      */
     readonly location: pulumi.Input<string>;
     /**
+     * The name of the virtual machine.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
      */
     readonly plan?: pulumi.Input<inputs.compute.Plan>;
@@ -199,10 +202,6 @@ export interface VirtualMachineArgs {
      * Resource tags
      */
     readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    /**
-     * The name of the virtual machine.
-     */
-    readonly vmName: pulumi.Input<string>;
     /**
      * The virtual machine zones.
      */

--- a/sdk/nodejs/compute/virtualMachineExtension.ts
+++ b/sdk/nodejs/compute/virtualMachineExtension.ts
@@ -44,7 +44,7 @@ export class VirtualMachineExtension extends pulumi.CustomResource {
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Describes the properties of a Virtual Machine Extension.
      */
@@ -80,22 +80,21 @@ export class VirtualMachineExtension extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
-            }
-            if (!args || args.vmExtensionName === undefined) {
-                throw new Error("Missing required property 'vmExtensionName'");
             }
             if (!args || args.vmName === undefined) {
                 throw new Error("Missing required property 'vmName'");
             }
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["vmExtensionName"] = args ? args.vmExtensionName : undefined;
             inputs["vmName"] = args ? args.vmName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -144,6 +143,10 @@ export interface VirtualMachineExtensionArgs {
      */
     readonly location: pulumi.Input<string>;
     /**
+     * The name of the virtual machine extension.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Describes the properties of a Virtual Machine Extension.
      */
     readonly properties?: pulumi.Input<inputs.compute.VirtualMachineExtensionProperties>;
@@ -155,10 +158,6 @@ export interface VirtualMachineExtensionArgs {
      * Resource tags
      */
     readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    /**
-     * The name of the virtual machine extension.
-     */
-    readonly vmExtensionName: pulumi.Input<string>;
     /**
      * The name of the virtual machine where the extension should be created or updated.
      */

--- a/sdk/nodejs/compute/virtualMachineScaleSet.ts
+++ b/sdk/nodejs/compute/virtualMachineScaleSet.ts
@@ -48,7 +48,7 @@ export class VirtualMachineScaleSet extends pulumi.CustomResource {
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
      */
@@ -100,22 +100,21 @@ export class VirtualMachineScaleSet extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            if (!args || args.vmScaleSetName === undefined) {
-                throw new Error("Missing required property 'vmScaleSetName'");
-            }
             inputs["identity"] = args ? args.identity : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["plan"] = args ? args.plan : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["sku"] = args ? args.sku : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["vmScaleSetName"] = args ? args.vmScaleSetName : undefined;
             inputs["zones"] = args ? args.zones : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -184,6 +183,10 @@ export interface VirtualMachineScaleSetArgs {
      */
     readonly location: pulumi.Input<string>;
     /**
+     * The name of the VM scale set to create or update.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
      */
     readonly plan?: pulumi.Input<inputs.compute.Plan>;
@@ -203,10 +206,6 @@ export interface VirtualMachineScaleSetArgs {
      * Resource tags
      */
     readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    /**
-     * The name of the VM scale set to create or update.
-     */
-    readonly vmScaleSetName: pulumi.Input<string>;
     /**
      * The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set.
      */

--- a/sdk/nodejs/compute/virtualMachineScaleSetVirtualmachine.ts
+++ b/sdk/nodejs/compute/virtualMachineScaleSetVirtualmachine.ts
@@ -40,7 +40,7 @@ export class VirtualMachineScaleSetVirtualmachine extends pulumi.CustomResource 
     /**
      * The virtual machine instance ID.
      */
-    public readonly instanceId!: pulumi.Output<string>;
+    public /*out*/ readonly instanceId!: pulumi.Output<string>;
     /**
      * Resource location
      */
@@ -48,7 +48,7 @@ export class VirtualMachineScaleSetVirtualmachine extends pulumi.CustomResource 
     /**
      * Resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
      */
@@ -102,11 +102,11 @@ export class VirtualMachineScaleSetVirtualmachine extends pulumi.CustomResource 
             inputs["zones"] = state ? state.zones : undefined;
         } else {
             const args = argsOrState as VirtualMachineScaleSetVirtualmachineArgs | undefined;
-            if (!args || args.instanceId === undefined) {
-                throw new Error("Missing required property 'instanceId'");
-            }
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
@@ -114,14 +114,14 @@ export class VirtualMachineScaleSetVirtualmachine extends pulumi.CustomResource 
             if (!args || args.vmScaleSetName === undefined) {
                 throw new Error("Missing required property 'vmScaleSetName'");
             }
-            inputs["instanceId"] = args ? args.instanceId : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["plan"] = args ? args.plan : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
             inputs["vmScaleSetName"] = args ? args.vmScaleSetName : undefined;
-            inputs["name"] = undefined /*out*/;
+            inputs["instanceId"] = undefined /*out*/;
             inputs["resources"] = undefined /*out*/;
             inputs["sku"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
@@ -189,13 +189,13 @@ export interface VirtualMachineScaleSetVirtualmachineState {
  */
 export interface VirtualMachineScaleSetVirtualmachineArgs {
     /**
-     * The instance ID of the virtual machine.
-     */
-    readonly instanceId: pulumi.Input<string>;
-    /**
      * Resource location
      */
     readonly location: pulumi.Input<string>;
+    /**
+     * The instance ID of the virtual machine.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
      */

--- a/sdk/nodejs/containerinstance/containerGroup.ts
+++ b/sdk/nodejs/containerinstance/containerGroup.ts
@@ -48,7 +48,7 @@ export class ContainerGroup extends pulumi.CustomResource {
     /**
      * The resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     public readonly properties!: pulumi.Output<outputs.containerinstance.ContainerGroupResponseProperties>;
     /**
      * The resource tags.
@@ -79,8 +79,8 @@ export class ContainerGroup extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ContainerGroupArgs | undefined;
-            if (!args || args.containerGroupName === undefined) {
-                throw new Error("Missing required property 'containerGroupName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.properties === undefined) {
                 throw new Error("Missing required property 'properties'");
@@ -88,13 +88,12 @@ export class ContainerGroup extends pulumi.CustomResource {
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            inputs["containerGroupName"] = args ? args.containerGroupName : undefined;
             inputs["identity"] = args ? args.identity : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -140,10 +139,6 @@ export interface ContainerGroupState {
  */
 export interface ContainerGroupArgs {
     /**
-     * The name of the container group.
-     */
-    readonly containerGroupName: pulumi.Input<string>;
-    /**
      * The identity of the container group, if configured.
      */
     readonly identity?: pulumi.Input<inputs.containerinstance.ContainerGroupIdentity>;
@@ -151,6 +146,10 @@ export interface ContainerGroupArgs {
      * The resource location.
      */
     readonly location?: pulumi.Input<string>;
+    /**
+     * The name of the container group.
+     */
+    readonly name: pulumi.Input<string>;
     readonly properties: pulumi.Input<inputs.containerinstance.ContainerGroupProperties>;
     /**
      * The name of the resource group.

--- a/sdk/nodejs/core/resourceGroup.ts
+++ b/sdk/nodejs/core/resourceGroup.ts
@@ -48,7 +48,7 @@ export class ResourceGroup extends pulumi.CustomResource {
     /**
      * The name of the resource group.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The resource group properties.
      */
@@ -85,15 +85,14 @@ export class ResourceGroup extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
-            if (!args || args.resourceGroupName === undefined) {
-                throw new Error("Missing required property 'resourceGroupName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             inputs["location"] = args ? args.location : undefined;
             inputs["managedBy"] = args ? args.managedBy : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
-            inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -150,13 +149,13 @@ export interface ResourceGroupArgs {
      */
     readonly managedBy?: pulumi.Input<string>;
     /**
+     * The name of the resource group to create or update. Can include alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the allowed characters.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * The resource group properties.
      */
     readonly properties?: pulumi.Input<inputs.core.ResourceGroupProperties>;
-    /**
-     * The name of the resource group to create or update. Can include alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the allowed characters.
-     */
-    readonly resourceGroupName: pulumi.Input<string>;
     /**
      * The tags attached to the resource group.
      */

--- a/sdk/nodejs/insights/component.ts
+++ b/sdk/nodejs/insights/component.ts
@@ -48,7 +48,7 @@ export class Component extends pulumi.CustomResource {
     /**
      * Azure resource name
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Properties that define an Application Insights component resource.
      */
@@ -88,19 +88,18 @@ export class Component extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            if (!args || args.resourceName === undefined) {
-                throw new Error("Missing required property 'resourceName'");
-            }
             inputs["kind"] = args ? args.kind : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["resourceName"] = args ? args.resourceName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -157,6 +156,10 @@ export interface ComponentArgs {
      */
     readonly location: pulumi.Input<string>;
     /**
+     * The name of the Application Insights component resource.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Properties that define an Application Insights component resource.
      */
     readonly properties?: pulumi.Input<inputs.insights.ApplicationInsightsComponentProperties>;
@@ -164,10 +167,6 @@ export interface ComponentArgs {
      * The name of the resource group. The name is case insensitive.
      */
     readonly resourceGroupName: pulumi.Input<string>;
-    /**
-     * The name of the Application Insights component resource.
-     */
-    readonly resourceName: pulumi.Input<string>;
     /**
      * Resource tags
      */

--- a/sdk/nodejs/network/networkInterface.ts
+++ b/sdk/nodejs/network/networkInterface.ts
@@ -48,7 +48,7 @@ export class NetworkInterface extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Properties of the network interface.
      */
@@ -82,8 +82,8 @@ export class NetworkInterface extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as NetworkInterfaceArgs | undefined;
-            if (!args || args.networkInterfaceName === undefined) {
-                throw new Error("Missing required property 'networkInterfaceName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
@@ -91,11 +91,10 @@ export class NetworkInterface extends pulumi.CustomResource {
             inputs["etag"] = args ? args.etag : undefined;
             inputs["id"] = args ? args.id : undefined;
             inputs["location"] = args ? args.location : undefined;
-            inputs["networkInterfaceName"] = args ? args.networkInterfaceName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -158,7 +157,7 @@ export interface NetworkInterfaceArgs {
     /**
      * The name of the network interface.
      */
-    readonly networkInterfaceName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Properties of the network interface.
      */

--- a/sdk/nodejs/network/networkSecurityGroup.ts
+++ b/sdk/nodejs/network/networkSecurityGroup.ts
@@ -48,7 +48,7 @@ export class NetworkSecurityGroup extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Properties of the network security group.
      */
@@ -82,20 +82,19 @@ export class NetworkSecurityGroup extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as NetworkSecurityGroupArgs | undefined;
-            if (!args || args.networkSecurityGroupName === undefined) {
-                throw new Error("Missing required property 'networkSecurityGroupName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["id"] = args ? args.id : undefined;
             inputs["location"] = args ? args.location : undefined;
-            inputs["networkSecurityGroupName"] = args ? args.networkSecurityGroupName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
             inputs["etag"] = undefined /*out*/;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -154,7 +153,7 @@ export interface NetworkSecurityGroupArgs {
     /**
      * The name of the network security group.
      */
-    readonly networkSecurityGroupName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Properties of the network security group.
      */

--- a/sdk/nodejs/network/publicIPAddress.ts
+++ b/sdk/nodejs/network/publicIPAddress.ts
@@ -48,7 +48,7 @@ export class PublicIPAddress extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Public IP address properties.
      */
@@ -92,22 +92,21 @@ export class PublicIPAddress extends pulumi.CustomResource {
             inputs["zones"] = state ? state.zones : undefined;
         } else {
             const args = argsOrState as PublicIPAddressArgs | undefined;
-            if (!args || args.publicIpAddressName === undefined) {
-                throw new Error("Missing required property 'publicIpAddressName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["id"] = args ? args.id : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
-            inputs["publicIpAddressName"] = args ? args.publicIpAddressName : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["sku"] = args ? args.sku : undefined;
             inputs["tags"] = args ? args.tags : undefined;
             inputs["zones"] = args ? args.zones : undefined;
             inputs["etag"] = undefined /*out*/;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -172,13 +171,13 @@ export interface PublicIPAddressArgs {
      */
     readonly location?: pulumi.Input<string>;
     /**
+     * The name of the public IP address.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Public IP address properties.
      */
     readonly properties?: pulumi.Input<inputs.network.PublicIPAddressPropertiesFormat>;
-    /**
-     * The name of the public IP address.
-     */
-    readonly publicIpAddressName: pulumi.Input<string>;
     /**
      * The name of the resource group.
      */

--- a/sdk/nodejs/network/virtualNetwork.ts
+++ b/sdk/nodejs/network/virtualNetwork.ts
@@ -48,7 +48,7 @@ export class VirtualNetwork extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Properties of the virtual network.
      */
@@ -82,20 +82,19 @@ export class VirtualNetwork extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as VirtualNetworkArgs | undefined;
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
-            }
-            if (!args || args.virtualNetworkName === undefined) {
-                throw new Error("Missing required property 'virtualNetworkName'");
             }
             inputs["etag"] = args ? args.etag : undefined;
             inputs["id"] = args ? args.id : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["virtualNetworkName"] = args ? args.virtualNetworkName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -156,6 +155,10 @@ export interface VirtualNetworkArgs {
      */
     readonly location?: pulumi.Input<string>;
     /**
+     * The name of the virtual network.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Properties of the virtual network.
      */
     readonly properties?: pulumi.Input<inputs.network.VirtualNetworkPropertiesFormat>;
@@ -167,8 +170,4 @@ export interface VirtualNetworkArgs {
      * Resource tags.
      */
     readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    /**
-     * The name of the virtual network.
-     */
-    readonly virtualNetworkName: pulumi.Input<string>;
 }

--- a/sdk/nodejs/resources/deployment.ts
+++ b/sdk/nodejs/resources/deployment.ts
@@ -44,7 +44,7 @@ export class Deployment extends pulumi.CustomResource {
     /**
      * The name of the deployment.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Deployment properties.
      */
@@ -72,8 +72,8 @@ export class Deployment extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as DeploymentArgs | undefined;
-            if (!args || args.deploymentName === undefined) {
-                throw new Error("Missing required property 'deploymentName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.properties === undefined) {
                 throw new Error("Missing required property 'properties'");
@@ -81,11 +81,10 @@ export class Deployment extends pulumi.CustomResource {
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            inputs["deploymentName"] = args ? args.deploymentName : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -126,13 +125,13 @@ export interface DeploymentState {
  */
 export interface DeploymentArgs {
     /**
-     * The name of the deployment.
-     */
-    readonly deploymentName: pulumi.Input<string>;
-    /**
      * The location to store the deployment data.
      */
     readonly location?: pulumi.Input<string>;
+    /**
+     * The name of the deployment.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * The deployment properties.
      */

--- a/sdk/nodejs/sql/server.ts
+++ b/sdk/nodejs/sql/server.ts
@@ -48,7 +48,7 @@ export class Server extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Represents the properties of the resource.
      */
@@ -85,19 +85,18 @@ export class Server extends pulumi.CustomResource {
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
-            if (!args || args.serverName === undefined) {
-                throw new Error("Missing required property 'serverName'");
-            }
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["serverName"] = args ? args.serverName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
             inputs["kind"] = undefined /*out*/;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -150,6 +149,10 @@ export interface ServerArgs {
      */
     readonly location: pulumi.Input<string>;
     /**
+     * The name of the server.
+     */
+    readonly name: pulumi.Input<string>;
+    /**
      * Represents the properties of the resource.
      */
     readonly properties?: pulumi.Input<inputs.sql.ServerProperties>;
@@ -157,10 +160,6 @@ export interface ServerArgs {
      * The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.
      */
     readonly resourceGroupName: pulumi.Input<string>;
-    /**
-     * The name of the server.
-     */
-    readonly serverName: pulumi.Input<string>;
     /**
      * Resource tags.
      */

--- a/sdk/nodejs/sql/serverDatabase.ts
+++ b/sdk/nodejs/sql/serverDatabase.ts
@@ -48,7 +48,7 @@ export class ServerDatabase extends pulumi.CustomResource {
     /**
      * Resource name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The properties representing the resource.
      */
@@ -82,11 +82,11 @@ export class ServerDatabase extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ServerDatabaseArgs | undefined;
-            if (!args || args.databaseName === undefined) {
-                throw new Error("Missing required property 'databaseName'");
-            }
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
@@ -94,14 +94,13 @@ export class ServerDatabase extends pulumi.CustomResource {
             if (!args || args.serverName === undefined) {
                 throw new Error("Missing required property 'serverName'");
             }
-            inputs["databaseName"] = args ? args.databaseName : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["serverName"] = args ? args.serverName : undefined;
             inputs["tags"] = args ? args.tags : undefined;
             inputs["kind"] = undefined /*out*/;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -150,13 +149,13 @@ export interface ServerDatabaseState {
  */
 export interface ServerDatabaseArgs {
     /**
-     * The name of the database to be operated on (updated or created).
-     */
-    readonly databaseName: pulumi.Input<string>;
-    /**
      * Resource location.
      */
     readonly location: pulumi.Input<string>;
+    /**
+     * The name of the database to be operated on (updated or created).
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * The properties representing the resource.
      */

--- a/sdk/nodejs/storage/storageAccount.ts
+++ b/sdk/nodejs/storage/storageAccount.ts
@@ -52,7 +52,7 @@ export class StorageAccount extends pulumi.CustomResource {
     /**
      * The name of the resource
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Properties of the storage account.
      */
@@ -92,14 +92,14 @@ export class StorageAccount extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as StorageAccountArgs | undefined;
-            if (!args || args.accountName === undefined) {
-                throw new Error("Missing required property 'accountName'");
-            }
             if (!args || args.kind === undefined) {
                 throw new Error("Missing required property 'kind'");
             }
             if (!args || args.location === undefined) {
                 throw new Error("Missing required property 'location'");
+            }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
@@ -107,15 +107,14 @@ export class StorageAccount extends pulumi.CustomResource {
             if (!args || args.sku === undefined) {
                 throw new Error("Missing required property 'sku'");
             }
-            inputs["accountName"] = args ? args.accountName : undefined;
             inputs["identity"] = args ? args.identity : undefined;
             inputs["kind"] = args ? args.kind : undefined;
             inputs["location"] = args ? args.location : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["sku"] = args ? args.sku : undefined;
             inputs["tags"] = args ? args.tags : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -172,10 +171,6 @@ export interface StorageAccountState {
  */
 export interface StorageAccountArgs {
     /**
-     * The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
-     */
-    readonly accountName: pulumi.Input<string>;
-    /**
      * The identity of the resource.
      */
     readonly identity?: pulumi.Input<inputs.storage.Identity>;
@@ -187,6 +182,10 @@ export interface StorageAccountArgs {
      * Required. Gets or sets the location of the resource. This will be one of the supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.). The geo region of a resource cannot be changed once it is created, but if an identical geo region is specified on update, the request will succeed.
      */
     readonly location: pulumi.Input<string>;
+    /**
+     * The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
+     */
+    readonly name: pulumi.Input<string>;
     /**
      * The parameters used to create the storage account.
      */

--- a/sdk/nodejs/storage/storageAccountBlobServiceContainer.ts
+++ b/sdk/nodejs/storage/storageAccountBlobServiceContainer.ts
@@ -44,7 +44,7 @@ export class StorageAccountBlobServiceContainer extends pulumi.CustomResource {
     /**
      * The name of the resource
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Properties of the blob container.
      */
@@ -75,18 +75,17 @@ export class StorageAccountBlobServiceContainer extends pulumi.CustomResource {
             if (!args || args.accountName === undefined) {
                 throw new Error("Missing required property 'accountName'");
             }
-            if (!args || args.containerName === undefined) {
-                throw new Error("Missing required property 'containerName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["accountName"] = args ? args.accountName : undefined;
-            inputs["containerName"] = args ? args.containerName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["etag"] = undefined /*out*/;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -133,7 +132,7 @@ export interface StorageAccountBlobServiceContainerArgs {
     /**
      * The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.
      */
-    readonly containerName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Properties of the blob container.
      */

--- a/sdk/nodejs/storage/storageAccountBlobServiceContainerImmutabilityPolicy.ts
+++ b/sdk/nodejs/storage/storageAccountBlobServiceContainerImmutabilityPolicy.ts
@@ -44,7 +44,7 @@ export class StorageAccountBlobServiceContainerImmutabilityPolicy extends pulumi
     /**
      * The name of the resource
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * The properties of an ImmutabilityPolicy of a blob container.
      */
@@ -78,8 +78,8 @@ export class StorageAccountBlobServiceContainerImmutabilityPolicy extends pulumi
             if (!args || args.containerName === undefined) {
                 throw new Error("Missing required property 'containerName'");
             }
-            if (!args || args.immutabilityPolicyName === undefined) {
-                throw new Error("Missing required property 'immutabilityPolicyName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.properties === undefined) {
                 throw new Error("Missing required property 'properties'");
@@ -89,11 +89,10 @@ export class StorageAccountBlobServiceContainerImmutabilityPolicy extends pulumi
             }
             inputs["accountName"] = args ? args.accountName : undefined;
             inputs["containerName"] = args ? args.containerName : undefined;
-            inputs["immutabilityPolicyName"] = args ? args.immutabilityPolicyName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
             inputs["etag"] = undefined /*out*/;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -144,7 +143,7 @@ export interface StorageAccountBlobServiceContainerImmutabilityPolicyArgs {
     /**
      * The name of the blob container immutabilityPolicy within the specified storage account. ImmutabilityPolicy Name must be 'default'
      */
-    readonly immutabilityPolicyName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * The properties of an ImmutabilityPolicy of a blob container.
      */

--- a/sdk/nodejs/storage/storageAccountManagementPolicy.ts
+++ b/sdk/nodejs/storage/storageAccountManagementPolicy.ts
@@ -40,7 +40,7 @@ export class StorageAccountManagementPolicy extends pulumi.CustomResource {
     /**
      * The name of the resource
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Returns the Storage Account Data Policies Rules.
      */
@@ -70,17 +70,16 @@ export class StorageAccountManagementPolicy extends pulumi.CustomResource {
             if (!args || args.accountName === undefined) {
                 throw new Error("Missing required property 'accountName'");
             }
-            if (!args || args.managementPolicyName === undefined) {
-                throw new Error("Missing required property 'managementPolicyName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["accountName"] = args ? args.accountName : undefined;
-            inputs["managementPolicyName"] = args ? args.managementPolicyName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -123,7 +122,7 @@ export interface StorageAccountManagementPolicyArgs {
     /**
      * The name of the Storage Account Management Policy. It should always be 'default'
      */
-    readonly managementPolicyName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Returns the Storage Account Data Policies Rules.
      */

--- a/sdk/nodejs/storage/storageAccountObjectReplicationPolicy.ts
+++ b/sdk/nodejs/storage/storageAccountObjectReplicationPolicy.ts
@@ -40,7 +40,7 @@ export class StorageAccountObjectReplicationPolicy extends pulumi.CustomResource
     /**
      * The name of the resource
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Returns the Storage Account Object Replication Policy.
      */
@@ -70,17 +70,16 @@ export class StorageAccountObjectReplicationPolicy extends pulumi.CustomResource
             if (!args || args.accountName === undefined) {
                 throw new Error("Missing required property 'accountName'");
             }
-            if (!args || args.objectReplicationPolicyId === undefined) {
-                throw new Error("Missing required property 'objectReplicationPolicyId'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["accountName"] = args ? args.accountName : undefined;
-            inputs["objectReplicationPolicyId"] = args ? args.objectReplicationPolicyId : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -123,7 +122,7 @@ export interface StorageAccountObjectReplicationPolicyArgs {
     /**
      * The ID of object replication policy or 'default' if the policy ID is unknown.
      */
-    readonly objectReplicationPolicyId: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Returns the Storage Account Object Replication Policy.
      */

--- a/sdk/nodejs/storage/storageAccountPrivateEndpointConnection.ts
+++ b/sdk/nodejs/storage/storageAccountPrivateEndpointConnection.ts
@@ -40,7 +40,7 @@ export class StorageAccountPrivateEndpointConnection extends pulumi.CustomResour
     /**
      * The name of the resource
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Resource properties.
      */
@@ -70,17 +70,16 @@ export class StorageAccountPrivateEndpointConnection extends pulumi.CustomResour
             if (!args || args.accountName === undefined) {
                 throw new Error("Missing required property 'accountName'");
             }
-            if (!args || args.privateEndpointConnectionName === undefined) {
-                throw new Error("Missing required property 'privateEndpointConnectionName'");
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
             }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
             inputs["accountName"] = args ? args.accountName : undefined;
-            inputs["privateEndpointConnectionName"] = args ? args.privateEndpointConnectionName : undefined;
+            inputs["name"] = args ? args.name : undefined;
             inputs["properties"] = args ? args.properties : undefined;
             inputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
-            inputs["name"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -123,7 +122,7 @@ export interface StorageAccountPrivateEndpointConnectionArgs {
     /**
      * The name of the private endpoint connection associated with the Azure resource
      */
-    readonly privateEndpointConnectionName: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * Resource properties.
      */

--- a/sdk/schema/schema.json
+++ b/sdk/schema/schema.json
@@ -14280,6 +14280,10 @@
                     "type": "string",
                     "description": "Required for storage accounts where kind = BlobStorage. The access tier used for billing."
                 },
+                "allowBlobPublicAccess": {
+                    "type": "boolean",
+                    "description": "Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property."
+                },
                 "azureFilesIdentityBasedAuthentication": {
                     "$ref": "#/types/azurerm:storage:AzureFilesIdentityBasedAuthentication",
                     "description": "Provides the identity based authentication settings for Azure Files."
@@ -14299,6 +14303,10 @@
                 "largeFileSharesState": {
                     "type": "string",
                     "description": "Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled."
+                },
+                "minimumTlsVersion": {
+                    "type": "string",
+                    "description": "Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property."
                 },
                 "networkAcls": {
                     "$ref": "#/types/azurerm:storage:NetworkRuleSet",
@@ -14321,6 +14329,10 @@
                 "accessTier": {
                     "type": "string",
                     "description": "Required for storage accounts where kind = BlobStorage. The access tier used for billing."
+                },
+                "allowBlobPublicAccess": {
+                    "type": "boolean",
+                    "description": "Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property."
                 },
                 "azureFilesIdentityBasedAuthentication": {
                     "$ref": "#/types/azurerm:storage:AzureFilesIdentityBasedAuthenticationResponse",
@@ -14361,6 +14373,10 @@
                 "lastGeoFailoverTime": {
                     "type": "string",
                     "description": "Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the accountType is Standard_GRS or Standard_RAGRS."
+                },
+                "minimumTlsVersion": {
+                    "type": "string",
+                    "description": "Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property."
                 },
                 "networkAcls": {
                     "$ref": "#/types/azurerm:storage:NetworkRuleSetResponse",
@@ -18840,6 +18856,10 @@
                     "type": "string",
                     "description": "The name of the Redis cache."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the firewall rule."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:cache:RedisFirewallRuleProperties",
                     "description": "Properties required to create a firewall rule ."
@@ -18847,17 +18867,13 @@
                 "resourceGroupName": {
                     "type": "string",
                     "description": "The name of the resource group."
-                },
-                "ruleName": {
-                    "type": "string",
-                    "description": "The name of the firewall rule."
                 }
             },
             "requiredInputs": [
                 "cacheName",
+                "name",
                 "properties",
-                "resourceGroupName",
-                "ruleName"
+                "resourceGroupName"
             ],
             "stateInputs": {
                 "description": "A firewall rule on a redis cache has a name, and describes a contiguous range of IP addresses permitted to connect",
@@ -19064,7 +19080,7 @@
                     "type": "string",
                     "description": "Resource location."
                 },
-                "profileName": {
+                "name": {
                     "type": "string",
                     "description": "Name of the CDN profile which is unique within the resource group."
                 },
@@ -19087,7 +19103,7 @@
             },
             "requiredInputs": [
                 "location",
-                "profileName",
+                "name",
                 "resourceGroupName",
                 "sku"
             ],
@@ -19161,13 +19177,13 @@
                 "type"
             ],
             "inputProperties": {
-                "endpointName": {
-                    "type": "string",
-                    "description": "Name of the endpoint under the profile which is unique globally."
-                },
                 "location": {
                     "type": "string",
                     "description": "Resource location."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the endpoint under the profile which is unique globally."
                 },
                 "profileName": {
                     "type": "string",
@@ -19187,8 +19203,8 @@
                 }
             },
             "requiredInputs": [
-                "endpointName",
                 "location",
+                "name",
                 "profileName",
                 "resourceGroupName"
             ],
@@ -19248,13 +19264,13 @@
                 "type"
             ],
             "inputProperties": {
-                "customDomainName": {
-                    "type": "string",
-                    "description": "Name of the custom domain within an endpoint."
-                },
                 "endpointName": {
                     "type": "string",
                     "description": "Name of the endpoint under the profile which is unique globally."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the custom domain within an endpoint."
                 },
                 "profileName": {
                     "type": "string",
@@ -19270,8 +19286,8 @@
                 }
             },
             "requiredInputs": [
-                "customDomainName",
                 "endpointName",
+                "name",
                 "profileName",
                 "resourceGroupName"
             ],
@@ -19339,7 +19355,7 @@
                     "type": "string",
                     "description": "Resource location."
                 },
-                "originName": {
+                "name": {
                     "type": "string",
                     "description": "Name of the origin that is unique within the endpoint."
                 },
@@ -19363,7 +19379,7 @@
             "requiredInputs": [
                 "endpointName",
                 "location",
-                "originName",
+                "name",
                 "profileName",
                 "resourceGroupName"
             ],
@@ -19427,7 +19443,7 @@
                     "type": "string",
                     "description": "Name of the endpoint under the profile which is unique globally."
                 },
-                "originGroupName": {
+                "name": {
                     "type": "string",
                     "description": "Name of the origin group which is unique within the endpoint."
                 },
@@ -19446,7 +19462,7 @@
             },
             "requiredInputs": [
                 "endpointName",
-                "originGroupName",
+                "name",
                 "profileName",
                 "resourceGroupName"
             ],
@@ -19510,13 +19526,13 @@
                 "type"
             ],
             "inputProperties": {
-                "availabilitySetName": {
-                    "type": "string",
-                    "description": "The name of the availability set."
-                },
                 "location": {
                     "type": "string",
                     "description": "Resource location"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the availability set."
                 },
                 "properties": {
                     "$ref": "#/types/azurerm:compute:AvailabilitySetProperties",
@@ -19536,8 +19552,8 @@
                 }
             },
             "requiredInputs": [
-                "availabilitySetName",
                 "location",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -19609,13 +19625,13 @@
                 "type"
             ],
             "inputProperties": {
-                "imageName": {
-                    "type": "string",
-                    "description": "The name of the image."
-                },
                 "location": {
                     "type": "string",
                     "description": "Resource location"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the image."
                 },
                 "properties": {
                     "$ref": "#/types/azurerm:compute:ImageProperties",
@@ -19631,8 +19647,8 @@
                 }
             },
             "requiredInputs": [
-                "imageName",
                 "location",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -19704,13 +19720,13 @@
                     "type": "string",
                     "description": "Resource location"
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the proximity placement group."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:compute:ProximityPlacementGroupProperties",
                     "description": "Describes the properties of a Proximity Placement Group."
-                },
-                "proximityPlacementGroupName": {
-                    "type": "string",
-                    "description": "The name of the proximity placement group."
                 },
                 "resourceGroupName": {
                     "type": "string",
@@ -19723,7 +19739,7 @@
             },
             "requiredInputs": [
                 "location",
-                "proximityPlacementGroupName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -19822,6 +19838,10 @@
                     "type": "string",
                     "description": "Resource location"
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the virtual machine."
+                },
                 "plan": {
                     "$ref": "#/types/azurerm:compute:Plan",
                     "description": "Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -\u003e**. Enter any required information and then click **Save**."
@@ -19838,10 +19858,6 @@
                     "type": "object",
                     "description": "Resource tags"
                 },
-                "vmName": {
-                    "type": "string",
-                    "description": "The name of the virtual machine."
-                },
                 "zones": {
                     "type": "array",
                     "items": {
@@ -19852,8 +19868,8 @@
             },
             "requiredInputs": [
                 "location",
-                "resourceGroupName",
-                "vmName"
+                "name",
+                "resourceGroupName"
             ],
             "stateInputs": {
                 "description": "Describes a Virtual Machine.",
@@ -19947,6 +19963,10 @@
                     "type": "string",
                     "description": "Resource location"
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the virtual machine extension."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:compute:VirtualMachineExtensionProperties",
                     "description": "Describes the properties of a Virtual Machine Extension."
@@ -19959,10 +19979,6 @@
                     "type": "object",
                     "description": "Resource tags"
                 },
-                "vmExtensionName": {
-                    "type": "string",
-                    "description": "The name of the virtual machine extension."
-                },
                 "vmName": {
                     "type": "string",
                     "description": "The name of the virtual machine where the extension should be created or updated."
@@ -19970,8 +19986,8 @@
             },
             "requiredInputs": [
                 "location",
+                "name",
                 "resourceGroupName",
-                "vmExtensionName",
                 "vmName"
             ],
             "stateInputs": {
@@ -20066,6 +20082,10 @@
                     "type": "string",
                     "description": "Resource location"
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the VM scale set to create or update."
+                },
                 "plan": {
                     "$ref": "#/types/azurerm:compute:Plan",
                     "description": "Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -\u003e**. Enter any required information and then click **Save**."
@@ -20086,10 +20106,6 @@
                     "type": "object",
                     "description": "Resource tags"
                 },
-                "vmScaleSetName": {
-                    "type": "string",
-                    "description": "The name of the VM scale set to create or update."
-                },
                 "zones": {
                     "type": "array",
                     "items": {
@@ -20100,8 +20116,8 @@
             },
             "requiredInputs": [
                 "location",
-                "resourceGroupName",
-                "vmScaleSetName"
+                "name",
+                "resourceGroupName"
             ],
             "stateInputs": {
                 "description": "Describes a Virtual Machine Scale Set.",
@@ -20278,13 +20294,13 @@
                 "zones"
             ],
             "inputProperties": {
-                "instanceId": {
-                    "type": "string",
-                    "description": "The instance ID of the virtual machine."
-                },
                 "location": {
                     "type": "string",
                     "description": "Resource location"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The instance ID of the virtual machine."
                 },
                 "plan": {
                     "$ref": "#/types/azurerm:compute:Plan",
@@ -20308,8 +20324,8 @@
                 }
             },
             "requiredInputs": [
-                "instanceId",
                 "location",
+                "name",
                 "resourceGroupName",
                 "vmScaleSetName"
             ],
@@ -20410,10 +20426,6 @@
                 "type"
             ],
             "inputProperties": {
-                "containerGroupName": {
-                    "type": "string",
-                    "description": "The name of the container group."
-                },
                 "identity": {
                     "$ref": "#/types/azurerm:containerinstance:ContainerGroupIdentity",
                     "description": "The identity of the container group, if configured."
@@ -20421,6 +20433,10 @@
                 "location": {
                     "type": "string",
                     "description": "The resource location."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the container group."
                 },
                 "properties": {
                     "$ref": "#/types/azurerm:containerinstance:ContainerGroupProperties"
@@ -20435,7 +20451,7 @@
                 }
             },
             "requiredInputs": [
-                "containerGroupName",
+                "name",
                 "properties",
                 "resourceGroupName"
             ],
@@ -20518,13 +20534,13 @@
                     "type": "string",
                     "description": "The ID of the resource that manages this resource group."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the resource group to create or update. Can include alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the allowed characters."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:core:ResourceGroupProperties",
                     "description": "The resource group properties."
-                },
-                "resourceGroupName": {
-                    "type": "string",
-                    "description": "The name of the resource group to create or update. Can include alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the allowed characters."
                 },
                 "tags": {
                     "type": "object",
@@ -20533,7 +20549,7 @@
             },
             "requiredInputs": [
                 "location",
-                "resourceGroupName"
+                "name"
             ],
             "stateInputs": {
                 "description": "Resource group information.",
@@ -20617,6 +20633,10 @@
                     "type": "string",
                     "description": "Resource location"
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the Application Insights component resource."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:insights:ApplicationInsightsComponentProperties",
                     "description": "Properties that define an Application Insights component resource."
@@ -20624,10 +20644,6 @@
                 "resourceGroupName": {
                     "type": "string",
                     "description": "The name of the resource group. The name is case insensitive."
-                },
-                "resourceName": {
-                    "type": "string",
-                    "description": "The name of the Application Insights component resource."
                 },
                 "tags": {
                     "type": "object",
@@ -20637,8 +20653,8 @@
             "requiredInputs": [
                 "kind",
                 "location",
-                "resourceGroupName",
-                "resourceName"
+                "name",
+                "resourceGroupName"
             ],
             "stateInputs": {
                 "description": "An Application Insights component definition.",
@@ -20725,7 +20741,7 @@
                     "type": "string",
                     "description": "Resource location."
                 },
-                "networkInterfaceName": {
+                "name": {
                     "type": "string",
                     "description": "The name of the network interface."
                 },
@@ -20743,7 +20759,7 @@
                 }
             },
             "requiredInputs": [
-                "networkInterfaceName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -20913,7 +20929,7 @@
                     "type": "string",
                     "description": "Resource location."
                 },
-                "networkSecurityGroupName": {
+                "name": {
                     "type": "string",
                     "description": "The name of the network security group."
                 },
@@ -20931,7 +20947,7 @@
                 }
             },
             "requiredInputs": [
-                "networkSecurityGroupName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -21101,13 +21117,13 @@
                     "type": "string",
                     "description": "Resource location."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the public IP address."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:network:PublicIPAddressPropertiesFormat",
                     "description": "Public IP address properties."
-                },
-                "publicIpAddressName": {
-                    "type": "string",
-                    "description": "The name of the public IP address."
                 },
                 "resourceGroupName": {
                     "type": "string",
@@ -21130,7 +21146,7 @@
                 }
             },
             "requiredInputs": [
-                "publicIpAddressName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -21228,6 +21244,10 @@
                     "type": "string",
                     "description": "Resource location."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the virtual network."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:network:VirtualNetworkPropertiesFormat",
                     "description": "Properties of the virtual network."
@@ -21239,15 +21259,11 @@
                 "tags": {
                     "type": "object",
                     "description": "Resource tags."
-                },
-                "virtualNetworkName": {
-                    "type": "string",
-                    "description": "The name of the virtual network."
                 }
             },
             "requiredInputs": [
-                "resourceGroupName",
-                "virtualNetworkName"
+                "name",
+                "resourceGroupName"
             ],
             "stateInputs": {
                 "description": "Virtual Network resource.",
@@ -21466,13 +21482,13 @@
                 "type"
             ],
             "inputProperties": {
-                "deploymentName": {
-                    "type": "string",
-                    "description": "The name of the deployment."
-                },
                 "location": {
                     "type": "string",
                     "description": "The location to store the deployment data."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the deployment."
                 },
                 "properties": {
                     "$ref": "#/types/azurerm:resources:DeploymentProperties",
@@ -21484,7 +21500,7 @@
                 }
             },
             "requiredInputs": [
-                "deploymentName",
+                "name",
                 "properties",
                 "resourceGroupName"
             ],
@@ -21557,6 +21573,10 @@
                     "type": "string",
                     "description": "Resource location."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the server."
+                },
                 "properties": {
                     "$ref": "#/types/azurerm:sql:ServerProperties",
                     "description": "Represents the properties of the resource."
@@ -21565,10 +21585,6 @@
                     "type": "string",
                     "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal."
                 },
-                "serverName": {
-                    "type": "string",
-                    "description": "The name of the server."
-                },
                 "tags": {
                     "type": "object",
                     "description": "Resource tags."
@@ -21576,8 +21592,8 @@
             },
             "requiredInputs": [
                 "location",
-                "resourceGroupName",
-                "serverName"
+                "name",
+                "resourceGroupName"
             ],
             "stateInputs": {
                 "description": "Represents a server.",
@@ -21654,13 +21670,13 @@
                 "type"
             ],
             "inputProperties": {
-                "databaseName": {
-                    "type": "string",
-                    "description": "The name of the database to be operated on (updated or created)."
-                },
                 "location": {
                     "type": "string",
                     "description": "Resource location."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the database to be operated on (updated or created)."
                 },
                 "properties": {
                     "$ref": "#/types/azurerm:sql:DatabaseProperties",
@@ -21680,8 +21696,8 @@
                 }
             },
             "requiredInputs": [
-                "databaseName",
                 "location",
+                "name",
                 "resourceGroupName",
                 "serverName"
             ],
@@ -21769,10 +21785,6 @@
                 "type"
             ],
             "inputProperties": {
-                "accountName": {
-                    "type": "string",
-                    "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only."
-                },
                 "identity": {
                     "$ref": "#/types/azurerm:storage:Identity",
                     "description": "The identity of the resource."
@@ -21784,6 +21796,10 @@
                 "location": {
                     "type": "string",
                     "description": "Required. Gets or sets the location of the resource. This will be one of the supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.). The geo region of a resource cannot be changed once it is created, but if an identical geo region is specified on update, the request will succeed."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only."
                 },
                 "properties": {
                     "$ref": "#/types/azurerm:storage:StorageAccountPropertiesCreateParameters",
@@ -21803,9 +21819,9 @@
                 }
             },
             "requiredInputs": [
-                "accountName",
                 "kind",
                 "location",
+                "name",
                 "resourceGroupName",
                 "sku"
             ],
@@ -21888,7 +21904,7 @@
                     "type": "string",
                     "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only."
                 },
-                "containerName": {
+                "name": {
                     "type": "string",
                     "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number."
                 },
@@ -21903,7 +21919,7 @@
             },
             "requiredInputs": [
                 "accountName",
-                "containerName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -21971,7 +21987,7 @@
                     "type": "string",
                     "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number."
                 },
-                "immutabilityPolicyName": {
+                "name": {
                     "type": "string",
                     "description": "The name of the blob container immutabilityPolicy within the specified storage account. ImmutabilityPolicy Name must be 'default'"
                 },
@@ -21987,7 +22003,7 @@
             "requiredInputs": [
                 "accountName",
                 "containerName",
-                "immutabilityPolicyName",
+                "name",
                 "properties",
                 "resourceGroupName"
             ],
@@ -22047,7 +22063,7 @@
                     "type": "string",
                     "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only."
                 },
-                "managementPolicyName": {
+                "name": {
                     "type": "string",
                     "description": "The name of the Storage Account Management Policy. It should always be 'default'"
                 },
@@ -22062,7 +22078,7 @@
             },
             "requiredInputs": [
                 "accountName",
-                "managementPolicyName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -22116,7 +22132,7 @@
                     "type": "string",
                     "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only."
                 },
-                "objectReplicationPolicyId": {
+                "name": {
                     "type": "string",
                     "description": "The ID of object replication policy or 'default' if the policy ID is unknown."
                 },
@@ -22131,7 +22147,7 @@
             },
             "requiredInputs": [
                 "accountName",
-                "objectReplicationPolicyId",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {
@@ -22185,7 +22201,7 @@
                     "type": "string",
                     "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only."
                 },
-                "privateEndpointConnectionName": {
+                "name": {
                     "type": "string",
                     "description": "The name of the private endpoint connection associated with the Azure resource"
                 },
@@ -22200,7 +22216,7 @@
             },
             "requiredInputs": [
                 "accountName",
-                "privateEndpointConnectionName",
+                "name",
                 "resourceGroupName"
             ],
             "stateInputs": {


### PR DESCRIPTION
Fix #34.

That's another instance of #35 but now open to master.