### PR TITLE
Add copyright header

### DIFF
--- a/provider/pkg/provider/resources.go
+++ b/provider/pkg/provider/resources.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Noticed the file was missing a copyright header.

I, as a broken human being, get bothered by the inconsistency in things like this.

... in related news, we probably need to find/replace across all of these to set the year to 2020, since having everything say 2018 definitely doesn't seem right.