### PR TITLE
Decode error details from Azure responses

### DIFF
--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -586,9 +586,27 @@ func newResponseError(resp *http.Response) error {
 	}
 
 	errMsg := string(body)
+	var details []PulumiAzcoreErrorDetail
 	if e, ok := util.GetInnerMap(payload, "error"); ok {
 		if msg, ok := e["message"]; ok {
 			errMsg = msg.(string)
+		}
+
+		if detailsRaw, ok := e["details"]; ok {
+			if detailsArr, ok := detailsRaw.([]any); ok {
+				for _, detailRaw := range detailsArr {
+					if detailMap, ok := detailRaw.(map[string]any); ok {
+						detail := PulumiAzcoreErrorDetail{}
+						if msg, ok := detailMap["message"]; ok {
+							detail.Message = msg.(string)
+						}
+						if code, ok := detailMap["code"]; ok {
+							detail.Code = code.(string)
+						}
+						details = append(details, detail)
+					}
+				}
+			}
 		}
 	}
 
@@ -596,7 +614,13 @@ func newResponseError(resp *http.Response) error {
 		StatusCode: resp.StatusCode,
 		ErrorCode:  azcoreErr.ErrorCode,
 		Message:    errMsg,
+		Details:    details,
 	}
+}
+
+type PulumiAzcoreErrorDetail struct {
+	Message string
+	Code    string
 }
 
 // We use this error type instead of azcore.ResponseError because the latter has a very verbose error message (#3778).
@@ -604,11 +628,30 @@ type PulumiAzcoreResponseError struct {
 	StatusCode int
 	ErrorCode  string
 	Message    string
+	Details    []PulumiAzcoreErrorDetail
 }
 
 func (e *PulumiAzcoreResponseError) Error() string {
-	if e.ErrorCode == "" {
-		return fmt.Sprintf(`Status=%d Message="%s"`, e.StatusCode, e.Message)
+	messageParts := []string{fmt.Sprintf("Status=%d", e.StatusCode)}
+
+	if e.ErrorCode != "" {
+		messageParts = append(messageParts, fmt.Sprintf(`Code="%s"`, e.ErrorCode))
 	}
-	return fmt.Sprintf(`Status=%d Code="%s" Message="%s"`, e.StatusCode, e.ErrorCode, e.Message)
+
+	if e.Message != "" {
+		messageParts = append(messageParts, fmt.Sprintf(`Message="%s"`, e.Message))
+	}
+
+	if len(e.Details) > 0 {
+		details := []string{}
+		for _, detail := range e.Details {
+			formatted := fmt.Sprintf(`Message="%s" Code="%s"`, detail.Message, detail.Code)
+			details = append(details, formatted)
+		}
+
+		formatted := fmt.Sprintf("Details=[%s]", strings.Join(details, "; "))
+		messageParts = append(messageParts, formatted)
+	}
+
+	return strings.Join(messageParts, " ")
 }

--- a/provider/pkg/azure/client_azcore_test.go
+++ b/provider/pkg/azure/client_azcore_test.go
@@ -857,6 +857,17 @@ func TestNewResponseError(t *testing.T) {
 		assert.Equal(t, `Status=409 Message="{"foo": "bar"}"`, err.Error())
 	})
 
+	t.Run("with details", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: 409,
+			Body:       io.NopCloser(strings.NewReader(`{"error": {"message": "Foo already exists", "details": [{"message": "Detail 1", "code": "Code1"}, {"message": "Detail 2", "code": "Code2"}]}}`)),
+			Header:     http.Header{"X-Ms-Error-Code": []string{"Conflict"}},
+		}
+		err := newResponseError(resp)
+		require.Error(t, err)
+		assert.Equal(t, `Status=409 Code="Conflict" Message="Foo already exists" Details=[Message="Detail 1" Code="Code1"; Message="Detail 2" Code="Code2"]`, err.Error())
+	})
+
 	t.Run("404 with valid error code is recognized by IsNotFound", func(t *testing.T) {
 		resp := &http.Response{
 			StatusCode: 404,


### PR DESCRIPTION
Fixes #4663

### Description

This pull request enhances error handling in the Azure client by improving how error details are parsed and displayed. The changes introduce support for extracting and formatting nested error details from Azure responses, and they update the error output to include these details when present. Corresponding tests have also been added to ensure this functionality works as expected.

**Improvements to error parsing and reporting:**

* Updated `newResponseError` in `client_azcore.go` to extract the `details` field from Azure error responses, parse it into a new `PulumiAzcoreErrorDetail` struct, and include these details in the returned error object.
* Modified the `PulumiAzcoreResponseError` struct and its `Error()` method to format and display the new error details in the error message.
* Added the `PulumiAzcoreErrorDetail` struct to represent individual error details, including `message` and `code` fields.

**Testing enhancements:**

* Added a new test case in `client_azcore_test.go` to verify that errors with nested `details` are parsed and formatted correctly in the error message output.