### PR TITLE
Fix empty body on POST/PUT/PATCH requests

### DIFF
--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -151,13 +151,19 @@ func (c *azCoreClient) setHeaders(req *policy.Request, contentTypeJson bool) {
 	}
 }
 
+func isContentTypeJSON(method string) bool {
+	return method == http.MethodPost ||
+		method == http.MethodPut ||
+		method == http.MethodPatch
+}
+
 func (c *azCoreClient) initRequest(ctx context.Context, method, id string, queryParams map[string]any) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, method, runtime.JoinPaths(c.host, id))
 	if err != nil {
 		return nil, err
 	}
 
-	c.setHeaders(req, method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch)
+	c.setHeaders(req, isContentTypeJSON(method))
 
 	urlValues := MapToValues(queryParams)
 	// URL-unescape each value before encoding the URL (which encodes all values). Presumably, this
@@ -288,11 +294,16 @@ func (c *azCoreClient) putOrPatch(ctx context.Context, method string, id string,
 		return nil, false, err
 	}
 
-	if bodyProps != nil {
-		err = runtime.MarshalAsJSON(req, bodyProps)
-		if err != nil {
-			return nil, false, err
-		}
+	if bodyProps == nil && isContentTypeJSON(method) {
+		// populate body with empty payload {}
+		// when we are dealing with POST/PUT/PATCH
+		// otherwise we get 400 Bad Request
+		bodyProps = map[string]any{}
+	}
+
+	err = runtime.MarshalAsJSON(req, bodyProps)
+	if err != nil {
+		return nil, false, err
 	}
 
 	if serializationMutex != nil {

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -75,6 +75,15 @@ func TestRequiredContainers(t *testing.T) {
 	assertrefresh.HasNoChanges(t, pt.Refresh(t))
 }
 
+func TestWebAppSiteExtensions(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "site-extension")
+	defer func() {
+		pt.Destroy(t)
+	}()
+	pt.Up(t)
+}
+
 func TestSubResources(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "subresources")

--- a/provider/pkg/provider/test-programs/site-extension/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/site-extension/Pulumi.yaml
@@ -1,0 +1,44 @@
+name: webApp-site-extensions
+runtime: yaml
+description: Tests if we are able to add site extensions to a webApp
+
+resources:
+  resourceGroup:
+    type: azure-native:resources:ResourceGroup
+
+  asp-webbapp-w-java:
+    type: azure-native:web:AppServicePlan
+    properties:
+      name: asp-webbapp-w-java-dev
+      resourceGroupName: ${resourceGroup.name}
+      location: ${resourceGroup.location}
+      kind: app
+      sku:
+        name: S1
+        tier: Standard
+        size: S1
+        family: S
+        capacity: 1
+
+  demo-webapp-w-java:
+    type: azure-native:web:WebApp
+    properties:
+      name: demo-webapp-w-java-dev
+      resourceGroupName: ${resourceGroup.name}
+      location: ${asp-webbapp-w-java.location}
+      serverFarmId: ${asp-webbapp-w-java.id}
+      siteConfig:
+        appSettings:
+          - name: VAR
+            value: test
+        javaVersion: "11"
+        javaContainer: JAVA
+        javaContainerVersion: SE
+        alwaysOn: true
+
+  dynatrace-siteExtension:
+    type: azure-native:web:WebAppSiteExtension
+    properties:
+      resourceGroupName: ${resourceGroup.name}
+      name: ${demo-webapp-w-java.name}
+      siteExtensionId: Dynatrace


### PR DESCRIPTION
Fixes #558 

The problem was that Azure returned `400 Bad Request` because we were sending empty request body when creating the `WebAppSiteExtension` resource which only needs the URL to be identified. When the request body is empty, we send `{}` empty JSON instead of nothing. 

Tried removing the `Content-Type` header when the body is empty but that's not how Azure works, still received `400 Bad Request` but with this, sending `{}` does the trick. 

This PR includes e2e test that used to fail before the fix