### PR TITLE
Customize TagAtScope resource to use merge semantics when dealing with default tags

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/opttest"
@@ -182,6 +183,13 @@ func keyVaultClient(t *testing.T) *armkeyvault.VaultsClient {
 	tokenCred := azureCredentials(t)
 	sub := os.Getenv("ARM_SUBSCRIPTION_ID")
 	client, err := armkeyvault.NewVaultsClient(sub, tokenCred, nil)
+	require.NoError(t, err)
+	return client
+}
+
+func tagsClient(t *testing.T) *armresources.TagsClient {
+	sub := os.Getenv("ARM_SUBSCRIPTION_ID")
+	client, err := armresources.NewTagsClient(sub, azureCredentials(t), nil)
 	require.NoError(t, err)
 	return client
 }
@@ -713,6 +721,9 @@ func TestTagAtScopeAddedOnSecondDeploy_YAML(t *testing.T) {
 				},
 			},
 		},
+		"outputs": map[string]any{
+			"rg": "${resourcegroup.id}",
+		},
 		"plugins": plugins,
 	}
 
@@ -740,6 +751,33 @@ func TestTagAtScopeAddedOnSecondDeploy_YAML(t *testing.T) {
 
 	upResult = test.Up(t)
 	assert.Empty(t, upResult.StdErr, "second up should not have any errors")
+
+	// Retrieve the resource group ID from the stack output and verify that both TagAtScope
+	// resources' tags are present on the scope via the Azure API.
+	rgID, ok := upResult.Outputs["rg"]
+	require.True(t, ok, "rg output should be present")
+	rgIDStr, ok := rgID.Value.(string)
+	require.True(t, ok, "rg output should be a string")
+
+	ctx := context.Background()
+	tagsResp, err := tagsClient(t).GetAtScope(ctx, rgIDStr, nil)
+	require.NoError(t, err, "getting tags at scope should not error")
+
+	actualTags := map[string]string{}
+	if tagsResp.Properties != nil {
+		for k, v := range tagsResp.Properties.Tags {
+			if v != nil {
+				actualTags[k] = *v
+			}
+		}
+	}
+	t.Logf("Tags on scope: %v", actualTags)
+
+	// Tags from the "tags" resource.
+	assert.Equal(t, "test", actualTags["environment"])
+	assert.Equal(t, "pulumi", actualTags["managedBy"])
+	// Tags from the "tagsV2" resource.
+	assert.Equal(t, "tag", actualTags["another"])
 
 	// A subsequent preview should show no changes, confirming the operation is idempotent.
 	preview := test.Preview(t)

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -675,3 +675,65 @@ func TestManagedClusterHasPopulatedKubeletIdentity_YAML(t *testing.T) {
 	nonEmpty("objectId")
 	nonEmpty("resourceId")
 }
+
+// TestTagAtScopeAddedOnSecondDeploy_YAML verifies that a TagAtScope resource can be added
+// to a resource group after it has already been created, using the PATCH/Merge path.
+func TestTagAtScopeAddedOnSecondDeploy_YAML(t *testing.T) {
+	skipIfNotYamlInCI(t)
+	proj := tempProject(t)
+	azureBinaryDir := azureNativeBinaryDir(t)
+	test := createTest(t, proj.dir)
+
+	plugins := map[string]any{
+		"providers": []interface{}{
+			map[string]any{
+				"name": "azure-native",
+				"path": azureBinaryDir,
+			},
+		},
+	}
+
+	program := map[string]any{
+		"name":    proj.name,
+		"runtime": "yaml",
+		"resources": map[string]any{
+			"resourcegroup": map[string]any{
+				"type": "azure-native:resources:ResourceGroup",
+			},
+		},
+		"plugins": plugins,
+	}
+
+	// Deploy only the resource group.
+	updatePulumiYAML(t, test.WorkingDir(), program)
+
+	upResult := test.Up(t)
+	assert.Empty(t, upResult.StdErr, "first up should not have any errors")
+	defer test.Destroy(t)
+
+	// Add a TagAtScope resource on the second deploy.
+	program["resources"].(map[string]any)["tags"] = map[string]any{
+		"type": "azure-native:resources:TagAtScope",
+		"properties": map[string]any{
+			"scope": "${resourcegroup.id}",
+			"properties": map[string]any{
+				"tags": map[string]any{
+					"environment": "test",
+					"managedBy":   "pulumi",
+				},
+			},
+		},
+	}
+
+	updatePulumiYAML(t, test.WorkingDir(), program)
+
+	upResult = test.Up(t)
+	assert.Empty(t, upResult.StdErr, "second up should not have any errors")
+
+	// A subsequent preview should show no changes, confirming the operation is idempotent.
+	preview := test.Preview(t)
+	t.Logf("Preview STDOUT: \n%s", preview.StdOut)
+	assert.Equal(t, map[apitype.OpType]int{
+		apitype.OpSame: 3, // stack + resourcegroup + tags
+	}, preview.ChangeSummary)
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -700,6 +700,18 @@ func TestTagAtScopeAddedOnSecondDeploy_YAML(t *testing.T) {
 			"resourcegroup": map[string]any{
 				"type": "azure-native:resources:ResourceGroup",
 			},
+			"tags": map[string]any{
+				"type": "azure-native:resources:TagAtScope",
+				"properties": map[string]any{
+					"scope": "${resourcegroup.id}",
+					"properties": map[string]any{
+						"tags": map[string]any{
+							"environment": "test",
+							"managedBy":   "pulumi",
+						},
+					},
+				},
+			},
 		},
 		"plugins": plugins,
 	}
@@ -712,14 +724,13 @@ func TestTagAtScopeAddedOnSecondDeploy_YAML(t *testing.T) {
 	defer test.Destroy(t)
 
 	// Add a TagAtScope resource on the second deploy.
-	program["resources"].(map[string]any)["tags"] = map[string]any{
+	program["resources"].(map[string]any)["tagsV2"] = map[string]any{
 		"type": "azure-native:resources:TagAtScope",
 		"properties": map[string]any{
 			"scope": "${resourcegroup.id}",
 			"properties": map[string]any{
 				"tags": map[string]any{
-					"environment": "test",
-					"managedBy":   "pulumi",
+					"another": "tag",
 				},
 			},
 		},
@@ -734,6 +745,6 @@ func TestTagAtScopeAddedOnSecondDeploy_YAML(t *testing.T) {
 	preview := test.Preview(t)
 	t.Logf("Preview STDOUT: \n%s", preview.StdOut)
 	assert.Equal(t, map[apitype.OpType]int{
-		apitype.OpSame: 3, // stack + resourcegroup + tags
+		apitype.OpSame: 4, // stack + resourcegroup + tags + tagsV2
 	}, preview.ChangeSummary)
 }

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -84,6 +84,16 @@ func TestWebAppSiteExtensions(t *testing.T) {
 	pt.Up(t)
 }
 
+func TestTagAtScope(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "tag-at-scope")
+	defer func() {
+		pt.Destroy(t)
+	}()
+
+	pt.Up(t)
+}
+
 func TestSubResources(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "subresources")

--- a/provider/pkg/provider/test-programs/tag-at-scope/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/tag-at-scope/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: tag-at-scope
+runtime: yaml
+description: Deploys a resource group and applies tags to it using TagAtScope.
+resources:
+  resourceGroup:
+    type: azure-native:resources:ResourceGroup
+  tags:
+    type: azure-native:resources:TagAtScope
+    properties:
+      scope: ${resourceGroup.id}
+      properties:
+        tags:
+          environment: dev
+          managedBy: pulumi
+outputs:
+  resourceGroupName: ${resourceGroup.name}

--- a/provider/pkg/resources/customresources/custom_tagscope.go
+++ b/provider/pkg/resources/customresources/custom_tagscope.go
@@ -64,6 +64,12 @@ func tagAtScope(
 		path: tagAtScopePath,
 		tok:  tagAtScopeTok,
 
+		CanCreate: func(ctx context.Context, id string) error {
+			// we should always be able to `Create` since we are using
+			// Merge-based updates on a default resource
+			return nil
+		},
+
 		Create: func(ctx context.Context, id string, inputs resource.PropertyMap) (map[string]any, error) {
 			return patch(ctx, id, "Merge", inputs)
 		},

--- a/provider/pkg/resources/customresources/custom_tagscope.go
+++ b/provider/pkg/resources/customresources/custom_tagscope.go
@@ -1,0 +1,81 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+package customresources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/provider/crud"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/resources"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+const (
+	tagAtScopeTok  = "azure-native:resources:TagAtScope"
+	tagAtScopePath = "/{scope}/providers/Microsoft.Resources/tags/default"
+)
+
+// tagAtScope overrides Create, Update, and Delete for TagAtScope to use the PATCH endpoint
+// (Tags_UpdateAtScope) instead of the default PUT (Tags_CreateOrUpdateAtScope).
+//
+// This uses operation=Merge for Create/Update so that tags managed by Pulumi are added or
+// updated without disturbing tags on the scope that Pulumi does not own.  Delete uses
+// operation=Delete to remove only the tags that were declared in the resource, leaving
+// any other tags on the scope untouched.
+func tagAtScope(
+	lookupResource resources.ResourceLookupFunc,
+	crudClientFactory crud.ResourceCrudClientFactory,
+	azureClient azure.AzureClient,
+) (*CustomResource, error) {
+	var client crud.ResourceCrudClient
+	var asyncStyle string
+	if lookupResource != nil && crudClientFactory != nil {
+		res, found, err := lookupResource(tagAtScopeTok)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, fmt.Errorf("resource %q not found", tagAtScopeTok)
+		}
+		client = crudClientFactory(&res)
+		// PUT async-style is the same for PATCH
+		asyncStyle = res.PutAsyncStyle
+	}
+
+	// patch calls the PATCH endpoint with the given operation ("Merge" or "Delete").
+	// inputs must be in Pulumi SDK shape; PrepareAzureRESTBody converts them to ARM format.
+	patch := func(ctx context.Context, id, operation string, inputs resource.PropertyMap) (map[string]any, error) {
+		body, err := client.PrepareAzureRESTBody(id, inputs, nil)
+		if err != nil {
+			return nil, err
+		}
+		body["operation"] = operation
+		queryParams := map[string]any{"api-version": client.ApiVersion()}
+		resp, _, err := azureClient.Patch(ctx, id, body, queryParams, asyncStyle)
+		if err != nil {
+			return nil, err
+		}
+		return client.ResponseBodyToSdkOutputs(resp), nil
+	}
+
+	return &CustomResource{
+		path: tagAtScopePath,
+		tok:  tagAtScopeTok,
+
+		Create: func(ctx context.Context, id string, inputs resource.PropertyMap) (map[string]any, error) {
+			return patch(ctx, id, "Merge", inputs)
+		},
+
+		Update: func(ctx context.Context, id string, news, olds resource.PropertyMap) (map[string]any, error) {
+			return patch(ctx, id, "Merge", news)
+		},
+
+		// Delete removes only the tags declared in this resource, leaving other tags intact.
+		Delete: func(ctx context.Context, id string, previousInputs, state resource.PropertyMap) error {
+			_, err := patch(ctx, id, "Delete", previousInputs)
+			return err
+		},
+	}, nil
+}

--- a/provider/pkg/resources/customresources/custom_tagscope.go
+++ b/provider/pkg/resources/customresources/custom_tagscope.go
@@ -51,6 +51,10 @@ func tagAtScope(
 		if err != nil {
 			return nil, err
 		}
+		if body == nil {
+			// make sure body is non-nil so that populating it later doesn't panic
+			body = map[string]any{}
+		}
 		body["operation"] = operation
 		queryParams := map[string]any{"api-version": client.ApiVersion()}
 		resp, _, err := azureClient.Patch(ctx, id, body, queryParams, asyncStyle)

--- a/provider/pkg/resources/customresources/customresources.go
+++ b/provider/pkg/resources/customresources/customresources.go
@@ -246,6 +246,11 @@ func BuildCustomResources(
 		return nil, err
 	}
 
+	customTagAtScope, err := tagAtScope(lookupResource, crudClientFactory, azureClient)
+	if err != nil {
+		return nil, err
+	}
+
 	resources := []*CustomResource{
 		keyVaultAccessPolicy(armKVClient),
 
@@ -259,6 +264,7 @@ func BuildCustomResources(
 		pimRoleManagementPolicy,
 		pimRoleEligibilitySchedule,
 		customRoleAssignment,
+		customTagAtScope,
 	}
 
 	resources = append(resources, keyVaultSecret(cloud, tokenCred))


### PR DESCRIPTION
Fixes #3962

### Description

The problem here when using `TagAtScope` is that the resource tries to take control over the tags of a resource at the specified scope. When the resource at the scope already has tags, it fails creation. This PR customizes the behaviour of `TagAtScope` such that it uses `operation: Merge` both when creating and when updating. This makes it such that the resource does not interfere with any existing tags. When deleting the resource, it only deletes the ones that are in the state using `operation: Delete` 

Docs for [`operation`](https://learn.microsoft.com/en-us/rest/api/resources/tags/update-at-scope?view=rest-resources-2021-04-01#tagspatchoperation) and each of the available options `Replace`, `Merge` and `Delete`. 