### PR TITLE
Fix the default state used when deleting `servicebus.NamespaceNetworkRuleSet` resources

### DIFF
--- a/provider/pkg/openapi/defaults/defaultResourcesState.go
+++ b/provider/pkg/openapi/defaults/defaultResourcesState.go
@@ -66,8 +66,7 @@ var defaultResourcesStateRaw = map[string]map[string]interface{}{
 		"state": "Disabled",
 	},
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkRuleSets/default": {
-		"defaultAction":       "Deny",
-		"publicNetworkAccess": "Disabled",
+		"defaultAction": "Allow",
 	},
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/components/{resourceName}/currentbillingfeatures": {
 		"currentBillingFeatures": []string{"Basic"},
@@ -84,7 +83,7 @@ var defaultResourcesStateRaw = map[string]map[string]interface{}{
 		},
 	},
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/networkRuleSets/default": {
-		"defaultAction": "Deny",
+		"defaultAction": "Allow",
 	},
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/advisors/{advisorName}": {
 		"autoExecuteStatus": "Default",

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -140,6 +140,19 @@ func TestAutonaming(t *testing.T) {
 	assert.Contains(t, saname, "autonamingsa") // project + name + random suffix, no dashes
 }
 
+// Tests that we are able to delete the program that has
+// a NetworkRuleSet for the service bus namespace
+// which in case for Pulumi and Azure, means reverting the resource
+// to its default state {"defaultAction": "Allow"} when deleting
+// since it is a Singleton resource
+func TestServiceBusNetworkRuleset(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "servicebus-network-ruleset")
+	pt.Preview(t)
+	pt.Up(t)
+	pt.Destroy(t)
+}
+
 func TestTagging(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "tagging")

--- a/provider/pkg/provider/test-programs/servicebus-network-ruleset/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/servicebus-network-ruleset/Pulumi.yaml
@@ -1,0 +1,30 @@
+name: network-ruleset-e2e-test
+runtime: yaml
+description: Example of deploying then destroying a service bus which has a namespace network rule set
+resources:
+  resourceGroup:
+    type: azure-native:resources:ResourceGroup
+
+  serviceBusNamespace:
+    type: azure-native:servicebus:Namespace
+    properties:
+      resourceGroupName: ${resourceGroup.name}
+      sku:
+        name: Standard
+        tier: Standard
+
+  asbQueue:
+    type: azure-native:servicebus:Queue
+    properties:
+      enablePartitioning: true
+      namespaceName: ${serviceBusNamespace.name}
+      resourceGroupName: ${resourceGroup.name}
+      maxDeliveryCount: 10
+      requiresSession: true
+
+  networkRuleSet:
+    type: azure-native:servicebus:NamespaceNetworkRuleSet
+    properties:
+      defaultAction: Allow
+      namespaceName: ${serviceBusNamespace.name}
+      resourceGroupName: ${resourceGroup.name}


### PR DESCRIPTION
Fixes #4064

### Description

When dealing with "Singleton" resources, Pulumi can't actually DELELE the resources since they are bound to the parent resource that they are created with. Instead, the Delete implementation issues a PUT request to reset the singleton resource back to its default state which is `{ defaultAction: Allow }` in the case of the `servicebus.NamespaceNetworkRuleSet` resource. This PR fixes the used default state and adds an end-to-end test to ensure the fix works