### PR TITLE
Fix API version used in Read immediately after Create

### DIFF
--- a/provider/pkg/provider/crud/crud.go
+++ b/provider/pkg/provider/crud/crud.go
@@ -131,9 +131,16 @@ func (r *resourceCrudClient) ApiVersionIsUserInput() bool {
 }
 
 func (r *resourceCrudClient) PrepareAzureRESTIdAndQuery(inputs resource.PropertyMap) (string, map[string]any, error) {
+	apiVersion := r.res.APIVersion
+	if r.ApiVersionIsUserInput() {
+		if apiVersionInput, ok := inputs["apiVersion"]; ok {
+			apiVersion = apiVersionInput.StringValue()
+		}
+	}
+
 	return PrepareAzureRESTIdAndQuery(r.res.Path, r.res.PutParameters, inputs.Mappable(), map[string]any{
 		"subscriptionId": r.subscriptionID,
-		"api-version":    r.res.APIVersion,
+		"api-version":    apiVersion,
 	})
 }
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1047,8 +1047,15 @@ func (k *azureNativeProvider) Create(ctx context.Context, req *rpc.CreateRequest
 			return nil, azure.AzureError(err)
 		}
 	default:
+		inputsForRead := resource.PropertyMap{}
+		if res.ApiVersionIsUserInput {
+			if apiVersion, ok := inputs["apiVersion"]; ok {
+				inputsForRead["apiVersion"] = apiVersion
+			}
+		}
+
 		id, outputs, err = k.defaultCreate(ctx, req, inputs, id, queryParams, crudClient,
-			reader(customRes, crudClient, nil /* previousInputs, none for Create */))
+			reader(customRes, crudClient, inputsForRead))
 		if err != nil {
 			return nil, err
 		}

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -127,6 +127,15 @@ func TestParallelSubnetCreation(t *testing.T) {
 	assertrefresh.HasNoChanges(t, pt.Refresh(t))
 }
 
+func TestGenericResourceCreatingCongitiveServicesAccount(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "generic-resource-cognitive-services")
+	upResult := pt.Up(t)
+	t.Logf("std out:\n%s\n", upResult.StdOut)
+	errorMsg := "Failed to read resource after Create. Please report this issue."
+	assert.NotContainsf(t, upResult.StdOut, errorMsg, "Expected not to see error message '%s' in stderr", errorMsg)
+}
+
 func TestAutonaming(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "autonaming", opttest.Env("PULUMI_EXPERIMENTAL", "1"))

--- a/provider/pkg/provider/test-programs/generic-resource-cognitive-services/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/generic-resource-cognitive-services/Pulumi.yaml
@@ -1,0 +1,37 @@
+name: generic-resource-congitive-services
+description: Example testing creation of a generic resource for AI Foundry (CognitiveServices/AIServices)
+runtime: yaml
+
+resources:
+  resourceGroup:
+    type: azure-native:resources:ResourceGroup
+
+  random:
+    type: random:RandomString
+    properties:
+      length: 4
+      upper: false
+      special: false
+
+  ai-foundry:
+    type: azure-native:resources:Resource
+    properties:
+      resourceProviderNamespace: Microsoft.CognitiveServices
+      resourceType: accounts
+      apiVersion: 2025-07-01-preview
+      parentResourcePath: ""
+      location: ${resourceGroup.location}
+      resourceGroupName: ${resourceGroup.name}
+      kind: AIServices
+      sku:
+        name: S0
+      identity:
+        type: SystemAssigned
+      properties:
+        disableLocalAuth: true
+        allowProjectManagement: true
+        customSubDomainName: ai-foundry-${random.result}
+        publicNetworkAccess: Disabled
+        networkAcls:
+          defaultAction: Deny
+          bypass: AzureServices


### PR DESCRIPTION
Fixes #4337

### Description

When using the [generic resource](https://www.pulumi.com/registry/packages/azure-native/version-guide/#using-the-generic-resource) to provision resources in Azure, the user supplies the desired API version in the _inputs_ of the resource, not the one specified in the resource metadata. 

Then when we are creating the resource, we call `Read(...)` afterwards. However, when we called `Read(...)` we didn't give it the inputs used in `Create(...)` which means `Read(...)` defaulted to using the API version in the metadata rather than the API version in the inputs. 

This PR fixes the issue by giving the a subset of the inputs used in `Create(...)` to `Read(...)`, specifically the `{apiVersion}` so that they align. 
```go
inputsForRead := resource.PropertyMap{}
if res.ApiVersionIsUserInput {
	if apiVersion, ok := inputs["apiVersion"]; ok {
		inputsForRead["apiVersion"] = apiVersion
	}
}
```
The PR adds an end-to-end to test to verify the fix. Before the fix, deployment would work but still logs the failure `StdOut` but now we ensure that is no longer the case.