### PR TITLE
Forward query parameters on GET-shaped invokes

### DIFF
--- a/provider/pkg/azure/client.go
+++ b/provider/pkg/azure/client.go
@@ -24,6 +24,8 @@ type MockAzureClient struct {
 	GetIds []string
 	// API versions that were used in Get, in order
 	GetApiVersions []string
+	// Query params that were used in Get, in order
+	GetQueryParams []map[string]any
 
 	// If set, this response will be returned for all Get requests; otherwise nil.
 	GetResponse    map[string]any
@@ -54,6 +56,7 @@ func (m *MockAzureClient) CanCreate(ctx context.Context, id, path, apiVersion, r
 func (m *MockAzureClient) Get(ctx context.Context, id string, apiVersion string, queryParams map[string]any) (map[string]any, error) {
 	m.GetIds = append(m.GetIds, id)
 	m.GetApiVersions = append(m.GetApiVersions, apiVersion)
+	m.GetQueryParams = append(m.GetQueryParams, queryParams)
 	return m.GetResponse, m.GetResponseErr
 }
 func (m *MockAzureClient) Head(ctx context.Context, id string, apiVersion string) error {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -382,7 +382,7 @@ func (k *azureNativeProvider) Invoke(ctx context.Context, req *rpc.InvokeRequest
 
 		var response any
 		if res.GetParameters != nil {
-			response, err = k.azureClient.Get(ctx, id, res.APIVersion, nil)
+			response, err = k.azureClient.Get(ctx, id, res.APIVersion, query)
 		} else if res.PostParameters != nil {
 			if body == nil {
 				body = map[string]interface{}{}

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -423,6 +423,73 @@ func TestInvokeListSubscriptionsDefaultApiVersion(t *testing.T) {
 	assert.Equal(t, "2022-12-01", mockClient.GetApiVersions[0])
 }
 
+// Regression test for https://github.com/pulumi/pulumi-azure-native/issues/4701:
+// query parameters supplied as invoke arguments must be forwarded to the GET request.
+func TestInvokeForwardsGetQueryParams(t *testing.T) {
+	mockClient := &az.MockAzureClient{
+		GetResponse: map[string]any{},
+	}
+
+	conv := convert.NewSdkShapeConverterFull(map[string]resources.AzureAPIType{})
+	invoke := resources.AzureAPIInvoke{
+		APIVersion: "2023-04-01",
+		Path:       "/providers/Microsoft.Management/managementGroups/{groupId}",
+		GetParameters: []resources.AzureAPIParameter{
+			{
+				Name:     "groupId",
+				Location: "path",
+				Value:    &resources.AzureAPIProperty{Type: "string"},
+			},
+			{
+				Name:     "$expand",
+				Location: "query",
+				Value:    &resources.AzureAPIProperty{Type: "string", SdkName: "expand"},
+			},
+			{
+				Name:     "$recurse",
+				Location: "query",
+				Value:    &resources.AzureAPIProperty{Type: "boolean", SdkName: "recurse"},
+			},
+		},
+		Response: map[string]resources.AzureAPIProperty{},
+	}
+	tok := "azure-native:management:getManagementGroup"
+	resourceMap := &resources.APIMetadata{
+		Types:     resources.GoMap[resources.AzureAPIType]{},
+		Resources: resources.GoMap[resources.AzureAPIResource]{},
+		Invokes:   resources.GoMap[resources.AzureAPIInvoke]{tok: invoke},
+	}
+
+	p := azureNativeProvider{
+		azureClient: mockClient,
+		converter:   &conv,
+		resourceMap: resourceMap,
+	}
+
+	args, err := plugin.MarshalProperties(
+		resource.NewPropertyMapFromMap(map[string]interface{}{
+			"groupId": "tenant-123",
+			"expand":  "children",
+			"recurse": true,
+		}),
+		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+	)
+	require.NoError(t, err)
+
+	_, err = p.Invoke(context.Background(), &rpc.InvokeRequest{
+		Tok:  tok,
+		Args: args,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mockClient.GetIds, 1)
+	assert.Equal(t, "/providers/Microsoft.Management/managementGroups/tenant-123", mockClient.GetIds[0])
+	require.Len(t, mockClient.GetQueryParams, 1)
+	// api-version is added by azCoreClient.Get itself, so we only assert the user-supplied params reach it.
+	assert.Equal(t, "children", mockClient.GetQueryParams[0]["$expand"])
+	assert.Equal(t, true, mockClient.GetQueryParams[0]["$recurse"])
+}
+
 func TestReader(t *testing.T) {
 	t.Run("custom Read", func(t *testing.T) {
 		var customReads []string


### PR DESCRIPTION
## Summary

The `Invoke` handler in `provider/pkg/provider/provider.go` computes a `query` map from the user's arguments via `crud.PrepareAzureRESTIdAndQuery`, then passes `nil` (instead of `query`) to `azureClient.Get`. The POST branch wires `query` through correctly, but the GET branch has silently dropped query parameters since #3639 widened the `Get` signature.

This affects every GET-shaped invoke whose spec declares query parameters — for example `management.getManagementGroup`'s `\$expand`, `\$recurse`, `\$filter`.

Fixes #4701.

## Changes

- `provider/pkg/provider/provider.go` — pass `query` instead of `nil` in the GET branch of `Invoke` (one-line fix).
- `provider/pkg/azure/client.go` — `MockAzureClient.Get` now records `queryParams` in a new `GetQueryParams` slice so tests can assert on them.
- `provider/pkg/provider/provider_test.go` — new `TestInvokeForwardsGetQueryParams` regression test modelled on `getManagementGroup`, asserting `\$expand` and `\$recurse` reach the underlying client.

## Test plan

- [x] `go test ./pkg/provider/... -run TestInvoke` passes locally
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)