### PR TITLE
Send x-ms-authorization-auxiliary header when auxiliaryTenantIds is configured

### DIFF
--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -47,14 +47,13 @@ type azCoreClient struct {
 
 func initPipelineOpts(azureCloud cloud.Configuration, opts *arm.ClientOptions) *arm.ClientOptions {
 	if opts == nil {
-		opts = &arm.ClientOptions{
-			ClientOptions: policy.ClientOptions{
-				Cloud: azureCloud,
-				Telemetry: policy.TelemetryOptions{
-					ApplicationID: fmt.Sprintf("pulumi-azure-native/%s", version.Version),
-				},
-			},
-		}
+		opts = &arm.ClientOptions{}
+	}
+	if opts.Cloud.ActiveDirectoryAuthorityHost == "" {
+		opts.Cloud = azureCloud
+	}
+	if opts.Telemetry.ApplicationID == "" {
+		opts.Telemetry.ApplicationID = fmt.Sprintf("pulumi-azure-native/%s", version.Version)
 	}
 
 	// azcore logging will only happen at log level 9.

--- a/provider/pkg/azure/client_azcore_test.go
+++ b/provider/pkg/azure/client_azcore_test.go
@@ -94,6 +94,14 @@ func TestInitPipelineOpts(t *testing.T) {
 		opts := initPipelineOpts(cloud.AzurePublic, nil)
 		assert.True(t, opts.Retry.ShouldRetry(&http.Response{StatusCode: http.StatusGatewayTimeout}, nil))
 	})
+
+	t.Run("preserves caller-supplied AuxiliaryTenants", func(t *testing.T) {
+		auxTenants := []string{"tenant-a", "tenant-b"}
+		opts := initPipelineOpts(cloud.AzurePublic, &arm.ClientOptions{AuxiliaryTenants: auxTenants})
+		assert.Equal(t, auxTenants, opts.AuxiliaryTenants)
+		assert.Equal(t, cloud.AzurePublic, opts.ClientOptions.Cloud)
+		assert.Equal(t, fmt.Sprintf("pulumi-azure-native/%s", version.Version), opts.Telemetry.ApplicationID)
+	})
 }
 
 func TestNormalizeLocationHeader(t *testing.T) {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azcloud "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
@@ -280,7 +281,15 @@ func (k *azureNativeProvider) Configure(ctx context.Context,
 	logging.V(9).Infof("Azure cloud: %+v", k.cloud)
 	logging.V(9).Infof("Azure subscription ID: %s", k.subscriptionID)
 
-	k.azureClient, err = azure.NewAzCoreClient(credential, userAgent, k.cloud.Configuration, nil)
+	// AuxiliaryTenants tells the ARM pipeline to attach the `x-ms-authorization-auxiliary`
+	// header for cross-tenant requests.
+	var armOpts *arm.ClientOptions
+	if len(authConfig.auxTenants) > 0 {
+		armOpts = &arm.ClientOptions{
+			AuxiliaryTenants: authConfig.auxTenants,
+		}
+	}
+	k.azureClient, err = azure.NewAzCoreClient(credential, userAgent, k.cloud.Configuration, armOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #4726.

Sets `arm.ClientOptions.AuxiliaryTenants` from `authConfig.auxTenants` so the ARM pipeline attaches the `x-ms-authorization-auxiliary` header on outgoing requests. The credential-side `AdditionallyAllowedTenants` is left in place.

Adds unit test.
