### PR TITLE
Retain WebApp/WebAppSlot siteConfig as a readable output

### DIFF
--- a/provider/pkg/gen/properties.go
+++ b/provider/pkg/gen/properties.go
@@ -206,7 +206,7 @@ func (m *moduleGenerator) genProperties(resolvedSchema *openapi.Schema, variants
 		if resolvedProperty.ReadOnly && !variants.isOutput {
 			continue
 		}
-		if variants.isOutput && isWriteOnly(resolvedProperty) {
+		if variants.isOutput && isWriteOnly(resolvedProperty) && !m.isReadableOutput(name) {
 			continue
 		}
 
@@ -658,6 +658,36 @@ func isWriteOnly(schema *openapi.Schema) bool {
 		}
 	}
 	return true
+}
+
+// readableOutputs lists properties that the Azure spec annotates as write-only (an
+// "x-ms-mutability" without "read") but which the provider can nonetheless read back, so they
+// must be retained as resource outputs. Keyed by Module -> Resource -> property names.
+//
+// Web/WebApp(Slot).siteConfig: a GET of Microsoft.Web/sites does not return siteConfig (Azure
+// annotates it write-only because it "may contain sensitive information"), but the provider's
+// custom Read fetches it from GET .../config/web and merges it back (see
+// resources/customresources.makeWebAppResource, added in pulumi/pulumi-azure-native#3464).
+// Retaining the output is required for siteConfig to round-trip on refresh/import. This
+// regressed when the default Web API version advanced to 2024-11-01, which introduced the
+// x-ms-mutability annotation that strips the output.
+var readableOutputs = map[openapi.ModuleName]map[string]codegen.StringSet{
+	"Web": {
+		"WebApp":     codegen.NewStringSet("siteConfig"),
+		"WebAppSlot": codegen.NewStringSet("siteConfig"),
+	},
+}
+
+// isReadableOutput reports whether propertyName, although annotated write-only by
+// x-ms-mutability, should still be generated as an output for the resource currently being
+// generated, because the provider is able to read its value (e.g. via a custom Read).
+func (m *moduleGenerator) isReadableOutput(propertyName string) bool {
+	if resourceMap, ok := readableOutputs[m.moduleName]; ok {
+		if properties, ok := resourceMap[m.resourceName]; ok {
+			return properties.Has(propertyName)
+		}
+	}
+	return false
 }
 
 // getDiscriminator returns a property name and description for a discriminator if it's defined on the schema.

--- a/provider/pkg/gen/properties_test.go
+++ b/provider/pkg/gen/properties_test.go
@@ -103,6 +103,63 @@ func TestForceNew(t *testing.T) {
 	})
 }
 
+func TestIsReadableOutput(t *testing.T) {
+	webApp := moduleGenerator{moduleName: "Web", resourceName: "WebApp"}
+	webAppSlot := moduleGenerator{moduleName: "Web", resourceName: "WebAppSlot"}
+	plan := moduleGenerator{moduleName: "Web", resourceName: "AppServicePlan"}
+	otherModule := moduleGenerator{moduleName: "Storage", resourceName: "StorageAccount"}
+
+	assert.True(t, webApp.isReadableOutput("siteConfig"))
+	assert.True(t, webAppSlot.isReadableOutput("siteConfig"))
+	assert.False(t, webApp.isReadableOutput("someOtherProperty"))
+	assert.False(t, plan.isReadableOutput("siteConfig"))
+	assert.False(t, otherModule.isReadableOutput("siteConfig"))
+}
+
+func TestWriteOnlyOutputRetained(t *testing.T) {
+	// siteConfig as Azure models it on Microsoft.Web/sites since api-version 2024-11-01:
+	// settable on create/update, but not returned by a GET of the parent resource.
+	writeOnlySiteConfig := func() *openapi.Schema {
+		return &openapi.Schema{
+			Schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"siteConfig": {
+							SchemaProps: spec.SchemaProps{Type: []string{"string"}},
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									extensionMutability: []interface{}{
+										extensionMutabilityCreate,
+										extensionMutabilityUpdate,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	variant := genPropertiesVariant{isOutput: true}
+
+	t.Run("stripped as write-only by default", func(t *testing.T) {
+		m := moduleGenerator{moduleName: "Web", resourceName: "AppServicePlan"}
+		props, err := m.genProperties(writeOnlySiteConfig(), variant)
+		require.NoError(t, err)
+		assert.NotContains(t, props.specs, "siteConfig")
+		assert.NotContains(t, props.properties, "siteConfig")
+	})
+
+	t.Run("retained for Web/WebApp via readableOutputs override", func(t *testing.T) {
+		m := moduleGenerator{moduleName: "Web", resourceName: "WebApp"}
+		props, err := m.genProperties(writeOnlySiteConfig(), variant)
+		require.NoError(t, err)
+		assert.Contains(t, props.specs, "siteConfig")
+		assert.Contains(t, props.properties, "siteConfig")
+	})
+}
+
 func TestNonObjectInvokeResponses(t *testing.T) {
 	m := moduleGenerator{
 		moduleName: "foo",


### PR DESCRIPTION
Fixes #4749. Related: #4263, #3464.

### Problem

Since the default `Microsoft.Web` version moved to `2024-11-01` (#4591), `Site.siteConfig` is `x-ms-mutability: ["create", "update"]` (no `"read"`), so `isWriteOnly` drops the `siteConfig` output (and `SiteConfigResponse`) from `web:WebApp` and `WebAppSlot`. That broke the custom Read from #3464, which merges `siteConfig` from `GET .../config/web` onto the WebApp; the merged value now has no output to land in, so `siteConfig` no longer round-trips on refresh/import. Bisect: `[Output("siteConfig")]` present through v3.15.0, gone from v3.16.0; the lock persists in all newer Web versions.

### Fix

Add a curated `readableOutputs` map (mirroring `noForceNewMap`) and consult it where outputs are stripped, so `siteConfig` is retained as an output for `web:WebApp` and `web:WebAppSlot`. The value is readable via the `/config/web` endpoint the custom Read already queries, so it round-trips again, including `ipSecurityRestrictions`, `minTlsVersion`, `ftpsState`, `healthCheckPath`, and auto-heal. Scoped to these two resources; `isWriteOnly` is unchanged globally.

### Validation

- Unit tests (added): `siteConfig` stripped by default, retained for `Web/WebApp`.
- Real schema regen: `WebApp.siteConfig` output plus `SiteConfigResponse` and `IpSecurityRestrictionResponse` reappear.
- End-to-end against a live Windows-container App Service: the rebuilt provider's Read captured `siteConfig` with all fields, including the security-relevant ones above.

### Note on regeneration

This is source-only so the logic is easy to review. It changes schema shape, so `schema.json` and the SDKs need regenerating (`make generate generate_docs`). Happy to push the regenerated artifacts to this branch, or run it on your side if you prefer.
