### PR TITLE
Fix automatic recovery of soft-deleted KeyVault secrets and keys

### DIFF
--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -127,6 +127,47 @@ func TestParallelSubnetCreation(t *testing.T) {
 	assertrefresh.HasNoChanges(t, pt.Refresh(t))
 }
 
+// TestKeyVaultSecretAndKeySoftDeleteRecovery verifies that re-creating a KeyVault secret/key after it has been
+// deleted (and therefore soft-deleted by Azure, which enforces soft-delete on all vaults) succeeds by recovering
+// the soft-deleted resource instead of failing with a conflict. See custom_keyvault.go and issues #1174, #1211.
+func TestKeyVaultSecretAndKeySoftDeleteRecovery(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "keyvault-soft-delete-recovery/step1")
+	defer func() {
+		pt.Destroy(t)
+	}()
+
+	up := pt.Up(t)
+	assertNonEmptyStringOutput(t, up, "secretUri")
+	assertNonEmptyStringOutput(t, up, "keyUri")
+
+	// Remove the secret and key. The provider deletes them via the KeyVault data plane, which soft-deletes them.
+	pt.UpdateSource(t, "test-programs", "keyvault-soft-delete-recovery", "step2")
+	pt.Up(t)
+
+	// Re-introduce the secret and key with the same names. Azure still has them in a soft-deleted state, so
+	// creating them again requires recovering them first; a plain ARM PUT would fail with a conflict.
+	pt.UpdateSource(t, "test-programs", "keyvault-soft-delete-recovery", "step1")
+	up = pt.Up(t)
+
+	upSummary := changesummary.FromStringIntMap(*up.Summary.ResourceChanges)
+	assert.Equal(t, 2, upSummary[apitype.OpCreate], "expected the secret and key to be (re-)created")
+
+	// Real ARM-issued outputs (as opposed to nil outputs from a create that never actually called ARM) confirm
+	// the resources were genuinely created, not just recovered and left stale.
+	assertNonEmptyStringOutput(t, up, "secretUri")
+	assertNonEmptyStringOutput(t, up, "keyUri")
+
+	assertrefresh.HasNoChanges(t, pt.Refresh(t))
+}
+
+func assertNonEmptyStringOutput(t *testing.T, up auto.UpResult, name string) {
+	t.Helper()
+	value, ok := up.Outputs[name].Value.(string)
+	require.True(t, ok, "expected output %q to be a string", name)
+	require.NotEmpty(t, value, "expected output %q to be non-empty", name)
+}
+
 func TestGenericResourceCreatingCongitiveServicesAccount(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "generic-resource-cognitive-services")

--- a/provider/pkg/provider/test-programs/keyvault-soft-delete-recovery/step1/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/keyvault-soft-delete-recovery/step1/Pulumi.yaml
@@ -1,0 +1,61 @@
+name: keyvault-soft-delete-recovery
+runtime: yaml
+description: Tests that a soft-deleted KeyVault secret/key is recovered on re-create
+variables:
+  clientConfig:
+    fn::invoke:
+      function: azure-native:authorization:getClientConfig
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  vault:
+    type: azure-native:keyvault:Vault
+    properties:
+      resourceGroupName: ${rg.name}
+      properties:
+        accessPolicies:
+          - objectId: ${clientConfig.objectId}
+            permissions:
+              keys:
+                - Get
+                - Create
+                - Delete
+                - List
+                - Recover
+                - Purge
+              secrets:
+                - Get
+                - List
+                - Set
+                - Delete
+                - Recover
+                - Purge
+            tenantId: ${clientConfig.tenantId}
+        sku:
+          family: A
+          name: standard
+        tenantId: ${clientConfig.tenantId}
+
+  secret:
+    type: azure-native:keyvault:Secret
+    properties:
+      resourceGroupName: ${rg.name}
+      vaultName: ${vault.name}
+      secretName: recoverable-secret
+      properties:
+        value: "recovered-value"
+
+  key:
+    type: azure-native:keyvault:Key
+    properties:
+      resourceGroupName: ${rg.name}
+      vaultName: ${vault.name}
+      keyName: recoverable-key
+      properties:
+        kty: "RSA"
+
+outputs:
+  secretUri: ${secret.properties.secretUri}
+  keyUri: ${key.keyUri}

--- a/provider/pkg/provider/test-programs/keyvault-soft-delete-recovery/step2/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/keyvault-soft-delete-recovery/step2/Pulumi.yaml
@@ -1,0 +1,43 @@
+name: keyvault-soft-delete-recovery
+runtime: yaml
+description: Tests that a soft-deleted KeyVault secret/key is recovered on re-create
+variables:
+  clientConfig:
+    fn::invoke:
+      function: azure-native:authorization:getClientConfig
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  vault:
+    type: azure-native:keyvault:Vault
+    properties:
+      resourceGroupName: ${rg.name}
+      properties:
+        accessPolicies:
+          - objectId: ${clientConfig.objectId}
+            permissions:
+              keys:
+                - Get
+                - Create
+                - Delete
+                - List
+                - Recover
+                - Purge
+              secrets:
+                - Get
+                - List
+                - Set
+                - Delete
+                - Recover
+                - Purge
+            tenantId: ${clientConfig.tenantId}
+        sku:
+          family: A
+          name: standard
+        tenantId: ${clientConfig.tenantId}
+
+# secret and key are intentionally omitted here: removing them from the desired state causes Pulumi to delete them,
+# which soft-deletes them in the vault (Azure Key Vault enforces soft-delete for all vaults). Re-introducing them
+# (see ../step1) then exercises the soft-delete recovery path in custom_keyvault.go.

--- a/provider/pkg/resources/customresources/custom_keyvault.go
+++ b/provider/pkg/resources/customresources/custom_keyvault.go
@@ -57,13 +57,9 @@ func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential)
 			deletedSecret, err := kvClient.GetDeletedSecret(ctx, secretName.StringValue(), nil)
 			if err == nil && deletedSecret.RecoveryID != nil {
 				logging.V(5).Infof("Found soft-deleted secret %s, recovering it before creating", secretName.StringValue())
-				poller, err := kvClient.BeginRecoverDeletedSecret(ctx, secretName.StringValue(), nil)
+				_, err = kvClient.RecoverDeletedSecret(ctx, secretName.StringValue(), nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to start recovery of soft-deleted secret %s", secretName.StringValue())
-				}
-				_, err = poller.PollUntilDone(ctx, nil)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to complete recovery of soft-deleted secret %s", secretName.StringValue())
+					return nil, errors.Wrapf(err, "failed to recover soft-deleted secret %s", secretName.StringValue())
 				}
 				logging.V(5).Infof("Successfully recovered soft-deleted secret %s", secretName.StringValue())
 			} else if err != nil {
@@ -143,13 +139,9 @@ func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *C
 			deletedKey, err := kvClient.GetDeletedKey(ctx, keyName.StringValue(), nil)
 			if err == nil && deletedKey.RecoveryID != nil {
 				logging.V(5).Infof("Found soft-deleted key %s, recovering it before creating", keyName.StringValue())
-				poller, err := kvClient.BeginRecoverDeletedKey(ctx, keyName.StringValue(), nil)
+				_, err = kvClient.RecoverDeletedKey(ctx, keyName.StringValue(), nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to start recovery of soft-deleted key %s", keyName.StringValue())
-				}
-				_, err = poller.PollUntilDone(ctx, nil)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to complete recovery of soft-deleted key %s", keyName.StringValue())
+					return nil, errors.Wrapf(err, "failed to recover soft-deleted key %s", keyName.StringValue())
 				}
 				logging.V(5).Infof("Successfully recovered soft-deleted key %s", keyName.StringValue())
 			} else if err != nil {

--- a/provider/pkg/resources/customresources/custom_keyvault.go
+++ b/provider/pkg/resources/customresources/custom_keyvault.go
@@ -19,11 +19,67 @@ import (
 
 // Note: These are "hybrid" resources: schema, create, update, read use default implementation, while DELETE is overridden.
 // DELETE is implemented via the KeyVault "data plane" API, because it isn't available via ARM.
+// CREATE is also customized to recover soft-deleted secrets/keys before creation.
 
 // keyVaultSecret creates a custom resource for Azure KeyVault Secret.
 func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *CustomResource {
 	return &CustomResource{
 		path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/secrets/{secretName}",
+		CanCreate: func(ctx context.Context, id string) error {
+			// We override CanCreate to handle soft-deleted secrets.
+			// If a soft-deleted secret exists, we'll recover it in the Create function.
+			// This prevents the default CanCreate from failing on soft-deleted resources.
+			return nil
+		},
+		Create: func(ctx context.Context, id string, inputs resource.PropertyMap) (map[string]interface{}, error) {
+			vaultName := inputs["vaultName"]
+			if !vaultName.HasValue() || !vaultName.IsString() {
+				return nil, errors.New("vaultName not found in inputs")
+			}
+			secretName := inputs["secretName"]
+			if !secretName.HasValue() || !secretName.IsString() {
+				return nil, errors.New("secretName not found in inputs")
+			}
+
+			keyVaultDNSSuffix := strings.TrimPrefix(cloud.Suffixes.KeyVaultDNS, ".")
+			if keyVaultDNSSuffix == "" {
+				return nil, errors.New("The provider configuration must include a value for keyVaultDNSSuffix")
+			}
+			vaultUrl := fmt.Sprintf("https://%s.%s", vaultName.StringValue(), keyVaultDNSSuffix)
+			kvClient, err := azsecrets.NewClient(vaultUrl, tokenCred, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			// Check if a soft-deleted secret exists and recover it if so
+			// Related issues: https://github.com/pulumi/pulumi-azure-native/issues/1174
+			//                 https://github.com/pulumi/pulumi-azure-native/issues/1211
+			deletedSecret, err := kvClient.GetDeletedSecret(ctx, secretName.StringValue(), nil)
+			if err == nil && deletedSecret.RecoveryID != nil {
+				logging.V(5).Infof("Found soft-deleted secret %s, recovering it before creating", secretName.StringValue())
+				poller, err := kvClient.BeginRecoverDeletedSecret(ctx, secretName.StringValue(), nil)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to start recovery of soft-deleted secret %s", secretName.StringValue())
+				}
+				_, err = poller.PollUntilDone(ctx, nil)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to complete recovery of soft-deleted secret %s", secretName.StringValue())
+				}
+				logging.V(5).Infof("Successfully recovered soft-deleted secret %s", secretName.StringValue())
+			} else if err != nil {
+				// Check if the error is a 404 (secret not in deleted state), which is fine
+				if respErr, ok := err.(*azcore.ResponseError); ok && respErr.StatusCode == http.StatusNotFound {
+					// Secret doesn't exist in deleted state, continue with normal creation
+					logging.V(9).Infof("Secret %s not found in deleted state, proceeding with normal creation", secretName.StringValue())
+				} else {
+					// Some other error occurred while checking for deleted secret
+					logging.V(5).Infof("Warning: error checking for deleted secret %s: %v. Continuing with creation attempt.", secretName.StringValue(), err)
+				}
+			}
+
+			// Return nil to let the default ARM-based creation flow handle the actual creation
+			return nil, nil
+		},
 		Delete: func(ctx context.Context, id string, inputs, state resource.PropertyMap) error {
 			vaultName := inputs["vaultName"]
 			if !vaultName.HasValue() || !vaultName.IsString() {
@@ -55,6 +111,61 @@ func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential)
 func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *CustomResource {
 	return &CustomResource{
 		path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/keys/{keyName}",
+		CanCreate: func(ctx context.Context, id string) error {
+			// We override CanCreate to handle soft-deleted keys.
+			// If a soft-deleted key exists, we'll recover it in the Create function.
+			// This prevents the default CanCreate from failing on soft-deleted resources.
+			return nil
+		},
+		Create: func(ctx context.Context, id string, inputs resource.PropertyMap) (map[string]interface{}, error) {
+			vaultName := inputs["vaultName"]
+			if !vaultName.HasValue() || !vaultName.IsString() {
+				return nil, errors.New("vaultName not found in inputs")
+			}
+			keyName := inputs["keyName"]
+			if !keyName.HasValue() || !keyName.IsString() {
+				return nil, errors.New("keyName not found in inputs")
+			}
+
+			keyVaultDNSSuffix := strings.TrimPrefix(cloud.Suffixes.KeyVaultDNS, ".")
+			if keyVaultDNSSuffix == "" {
+				return nil, errors.New("The provider configuration must include a value for keyVaultDNSSuffix")
+			}
+			vaultUrl := fmt.Sprintf("https://%s.%s", vaultName.StringValue(), keyVaultDNSSuffix)
+			kvClient, err := azkeys.NewClient(vaultUrl, tokenCred, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			// Check if a soft-deleted key exists and recover it if so
+			// Related issues: https://github.com/pulumi/pulumi-azure-native/issues/1174
+			//                 https://github.com/pulumi/pulumi-azure-native/issues/1211
+			deletedKey, err := kvClient.GetDeletedKey(ctx, keyName.StringValue(), nil)
+			if err == nil && deletedKey.RecoveryID != nil {
+				logging.V(5).Infof("Found soft-deleted key %s, recovering it before creating", keyName.StringValue())
+				poller, err := kvClient.BeginRecoverDeletedKey(ctx, keyName.StringValue(), nil)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to start recovery of soft-deleted key %s", keyName.StringValue())
+				}
+				_, err = poller.PollUntilDone(ctx, nil)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to complete recovery of soft-deleted key %s", keyName.StringValue())
+				}
+				logging.V(5).Infof("Successfully recovered soft-deleted key %s", keyName.StringValue())
+			} else if err != nil {
+				// Check if the error is a 404 (key not in deleted state), which is fine
+				if respErr, ok := err.(*azcore.ResponseError); ok && respErr.StatusCode == http.StatusNotFound {
+					// Key doesn't exist in deleted state, continue with normal creation
+					logging.V(9).Infof("Key %s not found in deleted state, proceeding with normal creation", keyName.StringValue())
+				} else {
+					// Some other error occurred while checking for deleted key
+					logging.V(5).Infof("Warning: error checking for deleted key %s: %v. Continuing with creation attempt.", keyName.StringValue(), err)
+				}
+			}
+
+			// Return nil to let the default ARM-based creation flow handle the actual creation
+			return nil, nil
+		},
 		Delete: func(ctx context.Context, id string, inputs, state resource.PropertyMap) error {
 			vaultName := inputs["vaultName"]
 			if !vaultName.HasValue() || !vaultName.IsString() {

--- a/provider/pkg/resources/customresources/custom_keyvault.go
+++ b/provider/pkg/resources/customresources/custom_keyvault.go
@@ -34,10 +34,13 @@ import (
 // Deletion (soft-delete) and the data plane's record of it becoming visible/recoverable are not instantaneous, so
 // the ARM PUT can still race a soft-delete that "just happened" (e.g. destroy immediately followed by up). To
 // tolerate that, creation is retried for a bounded time: each conflict re-checks for (and recovers) a soft-deleted
-// resource before trying the PUT again.
+// resource before trying the PUT again. If several consecutive conflicts turn up no soft-deleted resource at all,
+// the conflict is treated as a genuine, unrelated one (e.g. a real name collision) and surfaced immediately rather
+// than retried for the full timeout.
 const (
-	keyVaultRecoveryMaxWait      = 3 * time.Minute
-	keyVaultRecoveryPollInterval = 5 * time.Second
+	keyVaultRecoveryMaxWait       = 3 * time.Minute
+	keyVaultRecoveryPollInterval  = 5 * time.Second
+	keyVaultRecoveryGraceAttempts = 6 // ~30s of tolerance for soft-delete visibility lag before giving up
 )
 
 // keyVaultSecret creates a custom resource for Azure KeyVault Secret.
@@ -73,25 +76,27 @@ func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential,
 
 			// Related issues: https://github.com/pulumi/pulumi-azure-native/issues/1174
 			//                 https://github.com/pulumi/pulumi-azure-native/issues/1211
-			recoverIfSoftDeleted := func(ctx context.Context) error {
+			// recoverIfSoftDeleted reports whether a soft-deleted secret was found and recovered. Any error here
+			// (including an unexpected error while checking) is treated as "couldn't confirm", not fatal: the
+			// caller retries the create rather than aborting, since the check itself is exploratory.
+			recoverIfSoftDeleted := func(ctx context.Context) (recovered bool, err error) {
 				deletedSecret, err := kvClient.GetDeletedSecret(ctx, secretName.StringValue(), nil)
 				if err != nil {
 					var respErr *azcore.ResponseError
-					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
-						// Not (yet) visible as deleted on the data plane; the caller will retry the create.
-						return nil
+					if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusNotFound {
+						logging.V(5).Infof("Warning: error checking for a soft-deleted secret %s: %v", secretName.StringValue(), err)
 					}
-					return fmt.Errorf("failed to check for a soft-deleted secret %s: %w", secretName.StringValue(), err)
+					return false, nil
 				}
 				if deletedSecret.RecoveryID == nil {
-					return nil
+					return false, nil
 				}
 				logging.V(5).Infof("Found soft-deleted secret %s, recovering it before creating", secretName.StringValue())
 				if _, err := kvClient.RecoverDeletedSecret(ctx, secretName.StringValue(), nil); err != nil {
-					return fmt.Errorf("failed to recover soft-deleted secret %s: %w", secretName.StringValue(), err)
+					return false, fmt.Errorf("failed to recover soft-deleted secret %s: %w", secretName.StringValue(), err)
 				}
 				logging.V(5).Infof("Successfully recovered soft-deleted secret %s", secretName.StringValue())
-				return nil
+				return true, nil
 			}
 
 			return createOrUpdateArmResourceRecoveringSoftDeleted(ctx, crudClient, id, inputs, recoverIfSoftDeleted,
@@ -157,25 +162,27 @@ func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential,
 
 			// Related issues: https://github.com/pulumi/pulumi-azure-native/issues/1174
 			//                 https://github.com/pulumi/pulumi-azure-native/issues/1211
-			recoverIfSoftDeleted := func(ctx context.Context) error {
+			// recoverIfSoftDeleted reports whether a soft-deleted key was found and recovered. Any error here
+			// (including an unexpected error while checking) is treated as "couldn't confirm", not fatal: the
+			// caller retries the create rather than aborting, since the check itself is exploratory.
+			recoverIfSoftDeleted := func(ctx context.Context) (recovered bool, err error) {
 				deletedKey, err := kvClient.GetDeletedKey(ctx, keyName.StringValue(), nil)
 				if err != nil {
 					var respErr *azcore.ResponseError
-					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
-						// Not (yet) visible as deleted on the data plane; the caller will retry the create.
-						return nil
+					if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusNotFound {
+						logging.V(5).Infof("Warning: error checking for a soft-deleted key %s: %v", keyName.StringValue(), err)
 					}
-					return fmt.Errorf("failed to check for a soft-deleted key %s: %w", keyName.StringValue(), err)
+					return false, nil
 				}
 				if deletedKey.RecoveryID == nil {
-					return nil
+					return false, nil
 				}
 				logging.V(5).Infof("Found soft-deleted key %s, recovering it before creating", keyName.StringValue())
 				if _, err := kvClient.RecoverDeletedKey(ctx, keyName.StringValue(), nil); err != nil {
-					return fmt.Errorf("failed to recover soft-deleted key %s: %w", keyName.StringValue(), err)
+					return false, fmt.Errorf("failed to recover soft-deleted key %s: %w", keyName.StringValue(), err)
 				}
 				logging.V(5).Infof("Successfully recovered soft-deleted key %s", keyName.StringValue())
-				return nil
+				return true, nil
 			}
 
 			return createOrUpdateArmResourceRecoveringSoftDeleted(ctx, crudClient, id, inputs, recoverIfSoftDeleted,
@@ -224,25 +231,33 @@ func keyVaultResourceCrudClient(crudClientFactory crud.ResourceCrudClientFactory
 // chance to recover a same-named soft-deleted resource via the data plane, and the PUT is retried, for up to
 // keyVaultRecoveryMaxWait: soft-delete and its visibility/recovery on the data plane are not instantaneous, so a
 // create immediately following a delete can race them.
+//
+// If keyVaultRecoveryGraceAttempts consecutive conflicts turn up no soft-deleted resource at all, the conflict is
+// assumed to be a genuine, unrelated one (e.g. a real name collision, throttling, or a lock) rather than a
+// soft-delete race, and is returned immediately instead of being retried for the full keyVaultRecoveryMaxWait -
+// otherwise every such permanent conflict would silently block for 3 minutes before failing with an uninformative
+// timeout that discards the real ARM error.
 func createOrUpdateArmResourceRecoveringSoftDeleted(
 	ctx context.Context,
 	crudClient crud.ResourceCrudClient,
 	id string,
 	inputs resource.PropertyMap,
-	recoverIfSoftDeleted func(ctx context.Context) error,
+	recoverIfSoftDeleted func(ctx context.Context) (recovered bool, err error),
 	description string,
 ) (map[string]interface{}, error) {
+	bodyParams, err := crudClient.PrepareAzureRESTBody(id, inputs, nil)
+	if err != nil {
+		return nil, err
+	}
+	_, queryParams, err := crudClient.PrepareAzureRESTIdAndQuery(inputs)
+	if err != nil {
+		return nil, err
+	}
+
 	var outputs map[string]interface{}
-	err := util.RetryOperation(keyVaultRecoveryMaxWait, keyVaultRecoveryPollInterval, description,
+	unrecoverableConflicts := 0
+	err = util.RetryOperation(keyVaultRecoveryMaxWait, keyVaultRecoveryPollInterval, description,
 		func() (bool, error) {
-			bodyParams, err := crudClient.PrepareAzureRESTBody(id, inputs, nil)
-			if err != nil {
-				return false, err
-			}
-			_, queryParams, err := crudClient.PrepareAzureRESTIdAndQuery(inputs)
-			if err != nil {
-				return false, err
-			}
 			response, _, err := crudClient.CreateOrUpdate(ctx, id, bodyParams, queryParams)
 			if err == nil {
 				outputs = crudClient.ResponseBodyToSdkOutputs(response)
@@ -253,8 +268,17 @@ func createOrUpdateArmResourceRecoveringSoftDeleted(
 			if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusConflict {
 				return false, err
 			}
-			if recErr := recoverIfSoftDeleted(ctx); recErr != nil {
+			recovered, recErr := recoverIfSoftDeleted(ctx)
+			if recErr != nil {
 				return false, recErr
+			}
+			if recovered {
+				unrecoverableConflicts = 0
+				return false, nil
+			}
+			unrecoverableConflicts++
+			if unrecoverableConflicts >= keyVaultRecoveryGraceAttempts {
+				return false, err
 			}
 			return false, nil
 		})

--- a/provider/pkg/resources/customresources/custom_keyvault.go
+++ b/provider/pkg/resources/customresources/custom_keyvault.go
@@ -4,33 +4,53 @@ package customresources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
-	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure/cloud"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/provider/crud"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/resources"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
-// Note: These are "hybrid" resources: schema, create, update, read use default implementation, while DELETE is overridden.
+// Note: These are "hybrid" resources: schema, update, read use the default implementation, while CREATE and DELETE
+// are overridden.
+//
 // DELETE is implemented via the KeyVault "data plane" API, because it isn't available via ARM.
-// CREATE is also customized to recover soft-deleted secrets/keys before creation.
+//
+// CREATE recovers a soft-deleted secret/key via the data plane (if one exists) before creating/updating it via the
+// normal ARM PUT. Overriding Create means we're fully responsible for the ARM call ourselves: the provider does not
+// fall back to its default creation logic once a custom Create is set. See #1174, #1211.
+//
+// Deletion (soft-delete) and the data plane's record of it becoming visible/recoverable are not instantaneous, so
+// the ARM PUT can still race a soft-delete that "just happened" (e.g. destroy immediately followed by up). To
+// tolerate that, creation is retried for a bounded time: each conflict re-checks for (and recovers) a soft-deleted
+// resource before trying the PUT again.
+const (
+	keyVaultRecoveryMaxWait      = 3 * time.Minute
+	keyVaultRecoveryPollInterval = 5 * time.Second
+)
 
 // keyVaultSecret creates a custom resource for Azure KeyVault Secret.
-func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *CustomResource {
+func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential,
+	crudClientFactory crud.ResourceCrudClientFactory, lookupResource resources.ResourceLookupFunc,
+) (*CustomResource, error) {
+	crudClient, err := keyVaultResourceCrudClient(crudClientFactory, lookupResource, "azure-native:keyvault:Secret")
+	if err != nil {
+		return nil, err
+	}
+
 	return &CustomResource{
 		path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/secrets/{secretName}",
-		CanCreate: func(ctx context.Context, id string) error {
-			// We override CanCreate to handle soft-deleted secrets.
-			// If a soft-deleted secret exists, we'll recover it in the Create function.
-			// This prevents the default CanCreate from failing on soft-deleted resources.
-			return nil
-		},
 		Create: func(ctx context.Context, id string, inputs resource.PropertyMap) (map[string]interface{}, error) {
 			vaultName := inputs["vaultName"]
 			if !vaultName.HasValue() || !vaultName.IsString() {
@@ -51,30 +71,31 @@ func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential)
 				return nil, err
 			}
 
-			// Check if a soft-deleted secret exists and recover it if so
 			// Related issues: https://github.com/pulumi/pulumi-azure-native/issues/1174
 			//                 https://github.com/pulumi/pulumi-azure-native/issues/1211
-			deletedSecret, err := kvClient.GetDeletedSecret(ctx, secretName.StringValue(), nil)
-			if err == nil && deletedSecret.RecoveryID != nil {
-				logging.V(5).Infof("Found soft-deleted secret %s, recovering it before creating", secretName.StringValue())
-				_, err = kvClient.RecoverDeletedSecret(ctx, secretName.StringValue(), nil)
+			recoverIfSoftDeleted := func(ctx context.Context) error {
+				deletedSecret, err := kvClient.GetDeletedSecret(ctx, secretName.StringValue(), nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to recover soft-deleted secret %s", secretName.StringValue())
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+						// Not (yet) visible as deleted on the data plane; the caller will retry the create.
+						return nil
+					}
+					return fmt.Errorf("failed to check for a soft-deleted secret %s: %w", secretName.StringValue(), err)
+				}
+				if deletedSecret.RecoveryID == nil {
+					return nil
+				}
+				logging.V(5).Infof("Found soft-deleted secret %s, recovering it before creating", secretName.StringValue())
+				if _, err := kvClient.RecoverDeletedSecret(ctx, secretName.StringValue(), nil); err != nil {
+					return fmt.Errorf("failed to recover soft-deleted secret %s: %w", secretName.StringValue(), err)
 				}
 				logging.V(5).Infof("Successfully recovered soft-deleted secret %s", secretName.StringValue())
-			} else if err != nil {
-				// Check if the error is a 404 (secret not in deleted state), which is fine
-				if respErr, ok := err.(*azcore.ResponseError); ok && respErr.StatusCode == http.StatusNotFound {
-					// Secret doesn't exist in deleted state, continue with normal creation
-					logging.V(9).Infof("Secret %s not found in deleted state, proceeding with normal creation", secretName.StringValue())
-				} else {
-					// Some other error occurred while checking for deleted secret
-					logging.V(5).Infof("Warning: error checking for deleted secret %s: %v. Continuing with creation attempt.", secretName.StringValue(), err)
-				}
+				return nil
 			}
 
-			// Return nil to let the default ARM-based creation flow handle the actual creation
-			return nil, nil
+			return createOrUpdateArmResourceRecoveringSoftDeleted(ctx, crudClient, id, inputs, recoverIfSoftDeleted,
+				fmt.Sprintf("creating KeyVault secret %s", secretName.StringValue()))
 		},
 		Delete: func(ctx context.Context, id string, inputs, state resource.PropertyMap) error {
 			vaultName := inputs["vaultName"]
@@ -100,19 +121,20 @@ func keyVaultSecret(cloud cloud.Configuration, tokenCred azcore.TokenCredential)
 			_, err = kvClient.DeleteSecret(ctx, secretName.StringValue(), nil)
 			return reportDeletionError(err)
 		},
-	}
+	}, nil
 }
 
 // keyVaultKey creates a custom resource for Azure KeyVault Key.
-func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *CustomResource {
+func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential,
+	crudClientFactory crud.ResourceCrudClientFactory, lookupResource resources.ResourceLookupFunc,
+) (*CustomResource, error) {
+	crudClient, err := keyVaultResourceCrudClient(crudClientFactory, lookupResource, "azure-native:keyvault:Key")
+	if err != nil {
+		return nil, err
+	}
+
 	return &CustomResource{
 		path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/keys/{keyName}",
-		CanCreate: func(ctx context.Context, id string) error {
-			// We override CanCreate to handle soft-deleted keys.
-			// If a soft-deleted key exists, we'll recover it in the Create function.
-			// This prevents the default CanCreate from failing on soft-deleted resources.
-			return nil
-		},
 		Create: func(ctx context.Context, id string, inputs resource.PropertyMap) (map[string]interface{}, error) {
 			vaultName := inputs["vaultName"]
 			if !vaultName.HasValue() || !vaultName.IsString() {
@@ -133,30 +155,31 @@ func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *C
 				return nil, err
 			}
 
-			// Check if a soft-deleted key exists and recover it if so
 			// Related issues: https://github.com/pulumi/pulumi-azure-native/issues/1174
 			//                 https://github.com/pulumi/pulumi-azure-native/issues/1211
-			deletedKey, err := kvClient.GetDeletedKey(ctx, keyName.StringValue(), nil)
-			if err == nil && deletedKey.RecoveryID != nil {
-				logging.V(5).Infof("Found soft-deleted key %s, recovering it before creating", keyName.StringValue())
-				_, err = kvClient.RecoverDeletedKey(ctx, keyName.StringValue(), nil)
+			recoverIfSoftDeleted := func(ctx context.Context) error {
+				deletedKey, err := kvClient.GetDeletedKey(ctx, keyName.StringValue(), nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to recover soft-deleted key %s", keyName.StringValue())
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+						// Not (yet) visible as deleted on the data plane; the caller will retry the create.
+						return nil
+					}
+					return fmt.Errorf("failed to check for a soft-deleted key %s: %w", keyName.StringValue(), err)
+				}
+				if deletedKey.RecoveryID == nil {
+					return nil
+				}
+				logging.V(5).Infof("Found soft-deleted key %s, recovering it before creating", keyName.StringValue())
+				if _, err := kvClient.RecoverDeletedKey(ctx, keyName.StringValue(), nil); err != nil {
+					return fmt.Errorf("failed to recover soft-deleted key %s: %w", keyName.StringValue(), err)
 				}
 				logging.V(5).Infof("Successfully recovered soft-deleted key %s", keyName.StringValue())
-			} else if err != nil {
-				// Check if the error is a 404 (key not in deleted state), which is fine
-				if respErr, ok := err.(*azcore.ResponseError); ok && respErr.StatusCode == http.StatusNotFound {
-					// Key doesn't exist in deleted state, continue with normal creation
-					logging.V(9).Infof("Key %s not found in deleted state, proceeding with normal creation", keyName.StringValue())
-				} else {
-					// Some other error occurred while checking for deleted key
-					logging.V(5).Infof("Warning: error checking for deleted key %s: %v. Continuing with creation attempt.", keyName.StringValue(), err)
-				}
+				return nil
 			}
 
-			// Return nil to let the default ARM-based creation flow handle the actual creation
-			return nil, nil
+			return createOrUpdateArmResourceRecoveringSoftDeleted(ctx, crudClient, id, inputs, recoverIfSoftDeleted,
+				fmt.Sprintf("creating KeyVault key %s", keyName.StringValue()))
 		},
 		Delete: func(ctx context.Context, id string, inputs, state resource.PropertyMap) error {
 			vaultName := inputs["vaultName"]
@@ -182,11 +205,68 @@ func keyVaultKey(cloud cloud.Configuration, tokenCred azcore.TokenCredential) *C
 			_, err = kvClient.DeleteKey(ctx, keyName.StringValue(), nil)
 			return reportDeletionError(err)
 		},
+	}, nil
+}
+
+// keyVaultResourceCrudClient builds the ARM CRUD client used to actually create/update KeyVault secrets/keys.
+// crudClientFactory and lookupResource are nil when custom resources are built solely for schema/feature lookups
+// (see the package-level featureLookup var), in which case no client is needed.
+func keyVaultResourceCrudClient(crudClientFactory crud.ResourceCrudClientFactory, lookupResource resources.ResourceLookupFunc, tok string) (crud.ResourceCrudClient, error) {
+	if crudClientFactory == nil || lookupResource == nil {
+		return nil, nil
 	}
+	return createCrudClient(crudClientFactory, lookupResource, tok)
+}
+
+// createOrUpdateArmResourceRecoveringSoftDeleted issues the ARM PUT for a resource, mirroring the provider's
+// default creation flow (custom Create implementations must do this themselves: the provider does not fall back to
+// defaultCreate once a custom Create is set). If the PUT fails with a conflict, recoverIfSoftDeleted is given a
+// chance to recover a same-named soft-deleted resource via the data plane, and the PUT is retried, for up to
+// keyVaultRecoveryMaxWait: soft-delete and its visibility/recovery on the data plane are not instantaneous, so a
+// create immediately following a delete can race them.
+func createOrUpdateArmResourceRecoveringSoftDeleted(
+	ctx context.Context,
+	crudClient crud.ResourceCrudClient,
+	id string,
+	inputs resource.PropertyMap,
+	recoverIfSoftDeleted func(ctx context.Context) error,
+	description string,
+) (map[string]interface{}, error) {
+	var outputs map[string]interface{}
+	err := util.RetryOperation(keyVaultRecoveryMaxWait, keyVaultRecoveryPollInterval, description,
+		func() (bool, error) {
+			bodyParams, err := crudClient.PrepareAzureRESTBody(id, inputs, nil)
+			if err != nil {
+				return false, err
+			}
+			_, queryParams, err := crudClient.PrepareAzureRESTIdAndQuery(inputs)
+			if err != nil {
+				return false, err
+			}
+			response, _, err := crudClient.CreateOrUpdate(ctx, id, bodyParams, queryParams)
+			if err == nil {
+				outputs = crudClient.ResponseBodyToSdkOutputs(response)
+				return true, nil
+			}
+
+			var respErr *azure.PulumiAzcoreResponseError
+			if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusConflict {
+				return false, err
+			}
+			if recErr := recoverIfSoftDeleted(ctx); recErr != nil {
+				return false, recErr
+			}
+			return false, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return outputs, nil
 }
 
 func reportDeletionError(err error) error {
-	if detailed, ok := err.(*azcore.ResponseError); ok && detailed.StatusCode == http.StatusNotFound {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
 		return nil
 	}
 	return err

--- a/provider/pkg/resources/customresources/customresources.go
+++ b/provider/pkg/resources/customresources/customresources.go
@@ -268,8 +268,16 @@ func BuildCustomResources(
 		securityInsightsSourceControl(azureClient),
 	}
 
-	resources = append(resources, keyVaultSecret(cloud, tokenCred))
-	resources = append(resources, keyVaultKey(cloud, tokenCred))
+	kvSecret, err := keyVaultSecret(cloud, tokenCred, crudClientFactory, lookupResource)
+	if err != nil {
+		return nil, err
+	}
+	kvKey, err := keyVaultKey(cloud, tokenCred, crudClientFactory, lookupResource)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, kvSecret)
+	resources = append(resources, kvKey)
 
 	resources = append(resources, storageAccountStaticWebsite_azidentity(cloud, tokenCred))
 	resources = append(resources, newBlob_azidentity(cloud, tokenCred))

--- a/provider/pkg/util/retry.go
+++ b/provider/pkg/util/retry.go
@@ -9,7 +9,20 @@ import (
 
 // RetryOperation repeats the given operation until it succeeds, fails, or times out.
 // The given operation should return true if the operation is done, false if it should be retried.
+// The first attempt happens immediately; interval only applies between retries.
 func RetryOperation(timeout time.Duration, interval time.Duration, description string, operation func() (bool, error)) error {
+	attempt := func() (bool, error) {
+		done, err := operation()
+		if err != nil {
+			return false, fmt.Errorf("error during %s: %w", description, err)
+		}
+		return done, nil
+	}
+
+	if done, err := attempt(); err != nil || done {
+		return err
+	}
+
 	timeoutChan := time.After(timeout)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -19,12 +32,8 @@ func RetryOperation(timeout time.Duration, interval time.Duration, description s
 		case <-timeoutChan:
 			return fmt.Errorf("timed out during %s after %s", description, timeout)
 		case <-ticker.C:
-			done, err := operation()
-			if err != nil {
-				return fmt.Errorf("error during %s: %w", description, err)
-			}
-			if done {
-				return nil
+			if done, err := attempt(); err != nil || done {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This picks up @marekx's work in #4450 (thank you for the original idea and issue research!) and fixes a correctness bug found during review, plus adds test coverage.

**Problem** (from #4450): when a KeyVault secret/key is destroyed and recreated with the same name, Pulumi fails because Azure soft-deletes the underlying resource for 7-90 days:
```
pulumi up      # Creates secret
pulumi destroy # Soft-deletes secret
pulumi up      # ❌ FAILS: "secret already exists in deleted state"
```
Fixes #1174, #1211. Related to #2374, #3357.

**What changed vs. #4450:**
- The original `Create` override recovered the soft-deleted resource but then returned `nil, nil`, assuming the provider would fall back to its default ARM creation flow. It doesn't — once a custom `Create` is set, the provider never calls the default flow. This meant creation silently never actually happened via ARM (nil outputs, no real resource), for *every* create of a KeyVault secret/key, not just the soft-delete case.
- Fixed by having `Create` perform the ARM PUT itself (mirroring the provider's default creation flow) after checking for/recovering a soft-deleted resource.
- Removed the unconditional `CanCreate` override, which bypassed the "already exists" guard for every create (not just soft-deleted ones). The default `CanCreate` already tolerates the soft-delete case since a soft-deleted resource returns 404 on a normal ARM GET.
- Creation is retried through a bounded window (3 min, 5s interval) on conflict: soft-delete and its visibility/recovery on the data plane aren't instantaneous, so a create immediately following a delete can race them. This was confirmed live — an initial version without retries intermittently hit `AlreadyExists`/`ConflictError` from Azure when recreating right after a delete.
- Added `TestKeyVaultSecretAndKeySoftDeleteRecovery`, an e2e test that creates a secret+key, deletes them (soft-delete), then recreates them and verifies real ARM-issued outputs and a clean refresh. Verified passing against real Azure.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/resources/customresources/... -tags unit`
- [x] `go test -tags all -run TestKeyVaultSecretAndKeySoftDeleteRecovery -v ./pkg/provider/...` — passed against a live Azure subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)