### PR TITLE
Verify and fix Go SDK is consumable downstream

### DIFF
--- a/.github/scripts/go-sdk-consumer-check-main.go
+++ b/.github/scripts/go-sdk-consumer-check-main.go
@@ -1,0 +1,16 @@
+// Used by `make verify_go_sdk_consumable` to check that the generated Go SDK can be tidied and built
+// by a downstream consumer. See the target's comment in the Makefile and
+// https://github.com/pulumi/pulumi-azure-native/issues/4763 for why this exists.
+package main
+
+import (
+	resources "github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := resources.NewResourceGroup(ctx, "rg", nil)
+		return err
+	})
+}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -133,6 +133,14 @@ jobs:
         if: ${{ matrix.language != 'yaml' }}
         run: make build_${{ matrix.language }}
 
+      # Regression check for https://github.com/pulumi/pulumi-azure-native/issues/4763. `make build_go`
+      # above only tidies/builds the generated modules against themselves (via local `replace`
+      # directives), which can stay green even when the generated go.mod is broken for real consumers.
+      # This builds a throwaway module that requires the generated SDK the way a real user would.
+      - name: Verify Go SDK is consumable downstream
+        if: ${{ matrix.language == 'go' }}
+        run: make verify_go_sdk_consumable
+
       - name: Check worktree clean
         uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,6 @@ endif
 
 JAVA_GEN        := pulumi-java-gen
 
-# Seed version for google.golang.org/genproto used before `go mod tidy` runs on the generated Go SDK.
-# The genproto module was split into google.golang.org/genproto/googleapis/{api,rpc} - any version of
-# genproto older than the split still ships those packages too, and if `go mod tidy` ever picks the
-# pre-split module for one of them (which it can do non-deterministically, since the SDK's go.mod/go.sum
-# are regenerated from scratch on every release with no prior lockfile to anchor the resolution), every
-# downstream consumer's own `go mod tidy` fails with "ambiguous import" errors. Pinning to a version of
-# genproto published after the split guarantees `go mod tidy` only ever resolves the split modules. See
-# https://github.com/pulumi/pulumi-azure-native/issues/4763.
-GENPROTO_POST_SPLIT_PIN := v0.0.0-20240213162025-012b6fc9bca9
-
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 GOEXE ?= $(shell go env GOEXE)
@@ -386,8 +376,6 @@ export FAKE_MODULE
 	rm -rf $$(find sdk/pulumi-azure-native-sdk -mindepth 1 -maxdepth 1 ! -name ".git")
 	bin/$(CODEGEN) go $(PROVIDER_VERSION) $(CODEGEN_SCHEMA)
 	echo "Go version.txt: $$(cat sdk/pulumi-azure-native-sdk/version.txt)"
-	@# Seed a post-split genproto version before tidying - see GENPROTO_POST_SPLIT_PIN above.
-	find sdk/pulumi-azure-native-sdk -type d -maxdepth 1 -exec sh -c "cd \"{}\" && go mod edit -require=google.golang.org/genproto@$(GENPROTO_POST_SPLIT_PIN)" \;
 	@# Tidy up all go.mod files
 	find sdk/pulumi-azure-native-sdk -type d -maxdepth 1 -exec sh -c "cd \"{}\" && go mod tidy" \;
 	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,16 @@ endif
 
 JAVA_GEN        := pulumi-java-gen
 
+# Seed version for google.golang.org/genproto used before `go mod tidy` runs on the generated Go SDK.
+# The genproto module was split into google.golang.org/genproto/googleapis/{api,rpc} - any version of
+# genproto older than the split still ships those packages too, and if `go mod tidy` ever picks the
+# pre-split module for one of them (which it can do non-deterministically, since the SDK's go.mod/go.sum
+# are regenerated from scratch on every release with no prior lockfile to anchor the resolution), every
+# downstream consumer's own `go mod tidy` fails with "ambiguous import" errors. Pinning to a version of
+# genproto published after the split guarantees `go mod tidy` only ever resolves the split modules. See
+# https://github.com/pulumi/pulumi-azure-native/issues/4763.
+GENPROTO_POST_SPLIT_PIN := v0.0.0-20240213162025-012b6fc9bca9
+
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 GOEXE ?= $(shell go env GOEXE)
@@ -120,6 +130,9 @@ install_sdks: install_dotnet_sdk install_nodejs_sdk
 
 .PHONY: prepublish_go
 prepublish_go: .make/prepublish_go
+
+.PHONY: verify_go_sdk_consumable
+verify_go_sdk_consumable: .make/verify_go_sdk_consumable
 
 .PHONY: update_submodules
 update_submodules:
@@ -373,6 +386,8 @@ export FAKE_MODULE
 	rm -rf $$(find sdk/pulumi-azure-native-sdk -mindepth 1 -maxdepth 1 ! -name ".git")
 	bin/$(CODEGEN) go $(PROVIDER_VERSION) $(CODEGEN_SCHEMA)
 	echo "Go version.txt: $$(cat sdk/pulumi-azure-native-sdk/version.txt)"
+	@# Seed a post-split genproto version before tidying - see GENPROTO_POST_SPLIT_PIN above.
+	find sdk/pulumi-azure-native-sdk -type d -maxdepth 1 -exec sh -c "cd \"{}\" && go mod edit -require=google.golang.org/genproto@$(GENPROTO_POST_SPLIT_PIN)" \;
 	@# Tidy up all go.mod files
 	find sdk/pulumi-azure-native-sdk -type d -maxdepth 1 -exec sh -c "cd \"{}\" && go mod tidy" \;
 	@touch $@
@@ -424,6 +439,27 @@ export FAKE_MODULE
 
 .make/build_go: .make/generate_go_local
 	find sdk/pulumi-azure-native-sdk -type d -maxdepth 1 -exec sh -c "cd \"{}\" && go build" \;
+	@touch $@
+
+# Regression check for https://github.com/pulumi/pulumi-azure-native/issues/4763: `go mod tidy`/`go build`
+# inside sdk/pulumi-azure-native-sdk only ever tidy each module against itself, using local `replace`
+# directives to sibling directories in this checkout. That can stay green even when the generated
+# go.mod is broken for real consumers, because a downstream user's own `go mod tidy` combines their
+# go.mod's requirements (which include their own, possibly newer, direct requirement on
+# github.com/pulumi/pulumi/sdk/v3) with ours - and that combination is what can trigger "ambiguous
+# import" errors (e.g. from the google.golang.org/genproto module split) that never show up when we
+# tidy our module in isolation. This target simulates that external consumer: a throwaway module that
+# requires the generated SDK (via local replace, since it isn't published yet) with no go.sum of its
+# own, and makes sure `go mod tidy` and `go build` succeed the way they would for a real user.
+.make/verify_go_sdk_consumable: .make/generate_go_local
+	rm -rf .make/go-sdk-consumer-check
+	mkdir -p .make/go-sdk-consumer-check
+	cd .make/go-sdk-consumer-check && go mod init go-sdk-consumer-check
+	echo 'replace github.com/pulumi/pulumi-azure-native-sdk/resources/v3 => $(WORKING_DIR)/sdk/pulumi-azure-native-sdk/resources' >> .make/go-sdk-consumer-check/go.mod
+	echo 'replace github.com/pulumi/pulumi-azure-native-sdk/v3 => $(WORKING_DIR)/sdk/pulumi-azure-native-sdk' >> .make/go-sdk-consumer-check/go.mod
+	cp .github/scripts/go-sdk-consumer-check-main.go .make/go-sdk-consumer-check/main.go
+	cd .make/go-sdk-consumer-check && go mod tidy && go build ./...
+	rm -rf .make/go-sdk-consumer-check
 	@touch $@
 
 # Used by install* targets

--- a/provider/cmd/pulumi-gen-azure-native/main.go
+++ b/provider/cmd/pulumi-gen-azure-native/main.go
@@ -324,7 +324,7 @@ require (
 {{ if ne .SubmoduleName "" }}
 	github.com/pulumi/pulumi-azure-native-sdk{{ .ModuleVersionPath }} {{ .Version }}
 {{ end }}
-	github.com/pulumi/pulumi/sdk/v3 v3.37.2
+	github.com/pulumi/pulumi/sdk/v3 v3.253.0
 )
 
 {{ if ne .SubmoduleName "" }}


### PR DESCRIPTION
### Fix broken Go SDK go.mod

Fixes #4763

Since v3.20.0, the published Go SDK modules pin the pre-split, monolithic `google.golang.org/genproto` instead of the split `genproto/googleapis/{api,rpc}` modules that grpc/otel need. Any consumer whose own graph also needs the split modules (i.e. every Pulumi Go program) fails `go mod tidy` with ambiguous-import errors.

**Root cause:** the Go SDK's `go.mod` is regenerated from scratch every release with no prior `go.sum`, starting from a hardcoded `pulumi/sdk/v3` version in the codegen template that hadn't been touched since 2022 (`v3.37.2`). `go mod tidy` then has to re-derive the entire modern grpc/otel/genproto dependency graph from that 4-year-old anchor against whatever's on the proxy at that moment - bridging that large a gap is exactly where `go mod tidy`'s package resolution can non-deterministically land on the wrong (pre-split) `genproto` module instead of the split ones. Nothing in this repo changed between the working v3.19.0 and broken v3.20.0 releases; the drift is entirely external.

**CI didn't catch it** because `make build_go` only tidies each module against itself via local `replace` directives to sibling directories in this checkout - that stays green even when the go.mod is broken for real consumers, since the ambiguity only shows up once a downstream consumer's own requirements combine with ours during module resolution.

### Changes

- Bump the hardcoded `pulumi/sdk/v3` baseline in the `goModTemplate` (codegen) from `v3.37.2` to `v3.253.0`, a current release. This closes the gap `go mod tidy` has to bridge on every release, so it never needs to "rediscover" a resolution for the ambiguous genproto packages - `v3.253.0`'s own `go.mod` already requires the split modules directly. Verified this alone (no genproto pinning needed) produces a clean `go.mod` with no trace of the monolithic `genproto` module, across all 255 generated modules.
- Add `make verify_go_sdk_consumable`, which builds a throwaway module requiring the generated SDK the way a real downstream consumer would (fresh `go.mod`, no shared `go.sum`) and runs `go mod tidy && go build` against it, as a regression guard. Wired into `build-test.yml` after `make build_go`.

Verified locally: the template bump produces a clean `go.mod` across all 255 modules and all build successfully, and the new consumer check reproduces the issue's exact ambiguous-import errors when tested against a broken SDK, and passes against the fixed one.