### PR TITLE
Retry conflict error for TagAtScope resources

### DIFF
--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -144,6 +144,11 @@ func shouldRetryConflict(resp *http.Response) bool {
 			if responseErr.ErrorCode == "TransientError" {
 				return true
 			}
+
+			// for resources of type azure-native:resources:TagAtScope
+			if responseErr.ErrorCode == "ConflictingConcurrentWriteNotAllowed" {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Seen a conflict failure in CI with the following error:

> azure-native:resources:TagAtScope (tags):
error: Status=409 Code="ConflictingConcurrentWriteNotAllowed" Message="The operation was interrupted by a conflicting concurrent write on the same entity. Please retry later."

This PR makes it such that these kinds of errors are retried