### PR TITLE
Fix #4756: only force-replace immutable networkProfile fields

### DIFF
--- a/provider/pkg/gen/__snapshots__/gen_managedcluster_test.snap
+++ b/provider/pkg/gen/__snapshots__/gen_managedcluster_test.snap
@@ -413,8 +413,7 @@
   "networkProfile": {
    "$ref": "#/types/azure-native:containerservice:ContainerServiceNetworkProfile",
    "description": "The network configuration profile.",
-   "type": "object",
-   "willReplaceOnChanges": true
+   "type": "object"
   },
   "nodeProvisioningProfile": {
    "$ref": "#/types/azure-native:containerservice:ManagedClusterNodeProvisioningProfile",
@@ -1040,7 +1039,6 @@
       "containers": [
        "properties"
       ],
-      "forceNew": true,
       "type": "object"
      },
      "nodeProvisioningProfile": {

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -40,17 +40,20 @@ var forceNewMap = map[openapi.ModuleName]map[string]codegen.StringSet{
 			// Create-only, no update path exists at all in the AKS API:
 			"serviceCidr",
 			"serviceCidrs",
+			"podCidrs",
 			"dnsServiceIP",
 			"networkMode",
 			// `az aks update` accepts these, but only along a specific one-way migration
-			// (e.g. CNI -> CNI Overlay, azure -> cilium dataplane), not arbitrary edits.
-			// Force-new to stay conservative and avoid https://github.com/pulumi/pulumi-azure-native/issues/959.
+			// (e.g. CNI -> CNI Overlay, azure -> cilium dataplane, single-stack -> dual-stack),
+			// not arbitrary edits. Force-new to stay conservative and avoid
+			// https://github.com/pulumi/pulumi-azure-native/issues/959.
 			"networkPlugin",
 			"networkPluginMode",
 			"podCidr",
 			"networkDataplane",
 			"networkPolicy",
 			"outboundType",
+			"ipFamilies",
 			// AgentPoolNetworkProfile is a type shared with the standalone AgentPool resource (see
 			// below); nodePublicIPTags is create-only there too (no `az aks nodepool update`
 			// equivalent, unlike allowedHostPorts/applicationSecurityGroups). Listed here as well

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -31,13 +31,39 @@ var forceNewMap = map[openapi.ModuleName]map[string]codegen.StringSet{
 			"fqdnSubdomain",
 			"linuxProfile",
 			"location",
-			"networkProfile",
 			"nodeResourceGroup",
 			"windowsProfile",
+			// networkProfile (see https://github.com/pulumi/pulumi-azure-native/issues/4756):
+			// only the sub-properties below force a replacement. The rest of networkProfile
+			// (e.g. advancedNetworking, loadBalancerProfile, natGatewayProfile, loadBalancerSku)
+			// can be updated in place per `az aks update`.
+			// Create-only, no update path exists at all in the AKS API:
+			"serviceCidr",
+			"serviceCidrs",
+			"dnsServiceIP",
+			"networkMode",
+			// `az aks update` accepts these, but only along a specific one-way migration
+			// (e.g. CNI -> CNI Overlay, azure -> cilium dataplane), not arbitrary edits.
+			// Force-new to stay conservative and avoid https://github.com/pulumi/pulumi-azure-native/issues/959.
+			"networkPlugin",
+			"networkPluginMode",
+			"podCidr",
+			"networkDataplane",
+			"networkPolicy",
+			"outboundType",
+			// AgentPoolNetworkProfile is a type shared with the standalone AgentPool resource (see
+			// below); nodePublicIPTags is create-only there too (no `az aks nodepool update`
+			// equivalent, unlike allowedHostPorts/applicationSecurityGroups). Listed here as well
+			// since the type is generated once and whichever resource's pass generates it first
+			// determines its ForceNew flags for both.
+			"nodePublicIPTags",
 		),
 		"AgentPool": codegen.NewStringSet(
 			"gpuInstanceProfile",
 			"vmSize",
+			// networkProfile.nodePublicIPTags is create-only: no `az aks nodepool update` equivalent
+			// exists (unlike allowedHostPorts/applicationSecurityGroups, which are freely updatable).
+			"nodePublicIPTags",
 		),
 	},
 	"DocumentDB": {

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -642,6 +642,81 @@ var emptyTypes resources.TypeLookupFunc = func(t string) (*resources.AzureAPITyp
 	return nil, false, nil
 }
 
+// TestManagedClusterNetworkProfileOnlyForceNewsImmutableSubProperties is a regression test for
+// https://github.com/pulumi/pulumi-azure-native/issues/4756: ManagedCluster.networkProfile used to be
+// marked ForceNew as a whole object, so any change under it (e.g. toggling advancedNetworking, which AKS
+// supports updating in place via `az aks update`) forced a full cluster replacement. Only specific
+// sub-properties of ContainerServiceNetworkProfile that are genuinely immutable in the AKS API (e.g.
+// serviceCidr) should force a replacement; the rest should diff as a plain in-place update.
+func TestManagedClusterNetworkProfileOnlyForceNewsImmutableSubProperties(t *testing.T) {
+	res := resources.AzureAPIResource{
+		PutParameters: []resources.AzureAPIParameter{
+			{
+				Location: "body",
+				Name:     "bodyProperties",
+				Body: &resources.AzureAPIType{
+					Properties: map[string]resources.AzureAPIProperty{
+						"networkProfile": {Ref: "#/types/ContainerServiceNetworkProfile"},
+					},
+				},
+			},
+		},
+	}
+
+	lookupType := func(t string) (*resources.AzureAPIType, bool, error) {
+		return &resources.AzureAPIType{
+			Properties: map[string]resources.AzureAPIProperty{
+				"advancedNetworking": {},
+				"serviceCidr":        {ForceNew: true},
+			},
+		}, true, nil
+	}
+
+	t.Run("changing advancedNetworking only updates in place", func(t *testing.T) {
+		diff := resource.ObjectDiff{
+			Updates: map[resource.PropertyKey]resource.ValueDiff{
+				"networkProfile": {
+					Object: &resource.ObjectDiff{
+						Updates: map[resource.PropertyKey]resource.ValueDiff{
+							"advancedNetworking": {
+								Old: resource.PropertyValue{V: false},
+								New: resource.PropertyValue{V: true},
+							},
+						},
+					},
+				},
+			},
+		}
+		expected := map[string]*rpc.PropertyDiff{
+			"networkProfile.advancedNetworking": {Kind: rpc.PropertyDiff_UPDATE},
+		}
+		actual := calculateDetailedDiff(&res, lookupType, &diff)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("changing serviceCidr forces a replacement", func(t *testing.T) {
+		diff := resource.ObjectDiff{
+			Updates: map[resource.PropertyKey]resource.ValueDiff{
+				"networkProfile": {
+					Object: &resource.ObjectDiff{
+						Updates: map[resource.PropertyKey]resource.ValueDiff{
+							"serviceCidr": {
+								Old: resource.PropertyValue{V: "10.0.0.0/16"},
+								New: resource.PropertyValue{V: "10.1.0.0/16"},
+							},
+						},
+					},
+				},
+			},
+		}
+		expected := map[string]*rpc.PropertyDiff{
+			"networkProfile.serviceCidr": {Kind: rpc.PropertyDiff_UPDATE_REPLACE},
+		}
+		actual := calculateDetailedDiff(&res, lookupType, &diff)
+		assert.Equal(t, expected, actual)
+	})
+}
+
 func TestChangesAndReplacements_AddedPropertyCausesDiff(t *testing.T) {
 	changes, replacements := calculateChangesAndReplacementsForOneAddedProperty(t, "newvalue", nil)
 	assert.Len(t, changes, 1)

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -443,6 +443,46 @@ func TestUpgradeAksApiVersion_2_90_0(t *testing.T) {
 		optproviderupgrade.NewSourcePath(filepath.Join("test-programs", "upgrade-aks-api-version", "v3")))
 }
 
+// TestManagedClusterNetworkProfileForceNewOnlyImmutableFields is a regression test for issue #4756:
+// ManagedCluster.networkProfile used to be marked ForceNew as a whole object, so changing any
+// sub-property under it forced a full AKS cluster replacement, even sub-properties that AKS supports
+// updating in place (e.g. advancedNetworking/ACNS via `az aks update --enable-acns`).
+//
+// This only previews (rather than applies) the replacement scenario, since actually replacing a real
+// AKS cluster is slow and unnecessary to validate: the change under test is purely in the provider's
+// Diff logic (which properties get classified as forcing a replacement), not in the mechanics of
+// applying a replacement, which are unaffected.
+func TestManagedClusterNetworkProfileForceNewOnlyImmutableFields(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "aks-networkprofile-forcenew")
+	defer func() {
+		pt.Destroy(t)
+	}()
+
+	// Baseline: dnsServiceIP=10.0.0.10, advancedNetworking.enabled=false.
+	pt.Up(t)
+
+	// Changing only advancedNetworking (freely updatable per `az aks update`) should update in place.
+	pt.SetConfig(t, "advancedNetworkingEnabled", "true")
+	mutablePreview := pt.Preview(t)
+	assertpreview.HasNoReplacements(t, mutablePreview)
+	mutableSummary := changesummary.ChangeSummary(mutablePreview.ChangeSummary)
+	assert.Greater(t, mutableSummary[apitype.OpUpdate], 0,
+		"expected an in-place update when only advancedNetworking changes")
+
+	// Revert advancedNetworking so only dnsServiceIP (genuinely immutable, no `az aks update`
+	// equivalent) differs from the deployed baseline. That alone must force a replacement.
+	pt.SetConfig(t, "advancedNetworkingEnabled", "false")
+	pt.SetConfig(t, "dnsServiceIP", "10.0.1.10")
+	immutablePreview := pt.Preview(t)
+	immutableSummary := changesummary.ChangeSummary(immutablePreview.ChangeSummary)
+	replacementOps := immutableSummary[apitype.OpReplace] +
+		immutableSummary[apitype.OpCreateReplacement] +
+		immutableSummary[apitype.OpDeleteReplaced]
+	assert.Greater(t, replacementOps, 0,
+		"expected a replacement when changing the immutable dnsServiceIP sub-property")
+}
+
 func upgradeTest(t *testing.T, testProgramDir string, upgradeFromVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) {
 	t.Helper()
 	if testing.Short() {

--- a/provider/pkg/provider/test-programs/aks-networkprofile-forcenew/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/aks-networkprofile-forcenew/Pulumi.yaml
@@ -1,0 +1,49 @@
+name: aks-networkprofile-forcenew
+runtime: yaml
+description: |
+  Regression test for issue #4756: ManagedCluster.networkProfile used to be marked ForceNew as a
+  whole object, so any change under it forced a full AKS cluster replacement. This program lets the
+  test toggle two networkProfile sub-properties independently via config:
+
+  - dnsServiceIP: genuinely immutable in the AKS API (no equivalent `az aks update` parameter exists),
+    so changing it must force a ManagedCluster replacement.
+  - advancedNetworkingEnabled: freely updatable in place via `az aks update --enable-acns`, so changing
+    it must NOT force a replacement.
+
+config:
+  dnsServiceIP:
+    type: string
+    default: "10.0.0.10"
+  advancedNetworkingEnabled:
+    type: boolean
+    default: false
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+    properties:
+      location: eastus
+
+  cluster:
+    type: azure-native:containerservice:ManagedCluster
+    properties:
+      location: ${rg.location}
+      resourceGroupName: ${rg.name}
+      identity:
+        type: SystemAssigned
+      dnsPrefix: test-aks-4756
+      agentPoolProfiles:
+        - name: agentpool
+          count: 1
+          vmSize: Standard_DS2_v2
+          mode: System
+      networkProfile:
+        networkPlugin: azure
+        serviceCidr: 10.0.0.0/16
+        dnsServiceIP: ${dnsServiceIP}
+        advancedNetworking:
+          enabled: ${advancedNetworkingEnabled}
+
+outputs:
+  clusterId: ${cluster.id}
+  resourceGroupName: ${rg.name}


### PR DESCRIPTION
## Summary

Fixes #4756: changing `ManagedCluster.networkProfile.advancedNetworking` (ACNS) forced a full AKS cluster replacement, even though Azure supports updating it in place via `az aks update --enable-acns`.

The root cause was that `networkProfile` was marked as force-new as a *whole object* in `forceNewMap`, so any change under it — mutable or not — triggered a replacement. This PR replaces that with per-leaf-property force-new annotations, based on what AKS actually supports updating in place (verified against `az aks update`/`az aks nodepool update`):

- **`ManagedCluster.networkProfile`**: only `serviceCidr`, `serviceCidrs`, `dnsServiceIP`, `networkMode` (genuinely create-only, no update path exists) and `networkPlugin`, `networkPluginMode`, `podCidr`, `networkDataplane`, `networkPolicy`, `outboundType` (updatable only along a specific one-way migration, not arbitrary edits — kept conservative to avoid regressing #959) now force a replacement. Everything else (`advancedNetworking`, `loadBalancerProfile`, `natGatewayProfile`, `loadBalancerSku`) now diffs as a plain in-place update.
- **`AgentPool`/inline `ManagedCluster.agentPoolProfiles[]`**: while verifying the above, found that `AgentPoolNetworkProfile.networkProfile` was *also* being force-new'd wholesale, purely by an unrelated name collision in the same flat `forceNewMap` set (`networkProfile` matched both `ManagedCluster`'s own property and the unrelated per-agent-pool property of the same name). Fixed the same way: only `nodePublicIPTags` (create-only) forces a replacement now; `allowedHostPorts` and `applicationSecurityGroups` (confirmed freely updatable via `az aks nodepool update`) diff in place.

No `x-ms-mutability` annotations exist in the AKS OpenAPI spec for any of these properties, so this can't be derived automatically — the classification above is based on cross-referencing `az aks update --help` / `az aks nodepool update --help` against `az aks create --help` (params present on `update` are mutable; params present only on `create` are not).

## Changes

- `provider/pkg/gen/replacement.go`: replaced the whole-object `networkProfile` entries with the specific leaf properties described above, for both `ManagedCluster` and `AgentPool`.
- `provider/pkg/gen/__snapshots__/gen_managedcluster_test.snap`: updated golden snapshot to match.
- `provider/pkg/provider/diff_test.go`: added `TestManagedClusterNetworkProfileOnlyForceNewsImmutableSubProperties`, a unit test against `calculateDetailedDiff` covering both the mutable and immutable sub-property cases.
- `provider/pkg/provider/provider_e2e_test.go` + `test-programs/aks-networkprofile-forcenew/`: added `TestManagedClusterNetworkProfileForceNewOnlyImmutableFields`, an e2e test that deploys a real `ManagedCluster` and confirms via `Preview` that changing `advancedNetworking` alone produces no replacement while changing `dnsServiceIP` alone does.
- `provider/cmd/pulumi-resource-azure-native/schema.json`: regenerated (`make generate_docs`) to reflect the new `willReplaceOnChanges` placement.

## Test plan

- [x] `go test ./pkg/gen/...` — passes, including updated snapshot
- [x] `go test ./pkg/provider/... -tags unit` — passes (`TestManagedClusterNetworkProfileOnlyForceNewsImmutableSubProperties`, `TestSkuDiffingIsInsensitiveToAksPermutations`, and the rest of the suite)
- [x] `TestManagedClusterNetworkProfileForceNewOnlyImmutableFields` — ran live against a real AKS cluster: confirmed `advancedNetworking` change previews as an in-place update with no replacement, and `dnsServiceIP` change previews as a replacement; cluster and resource group destroyed cleanly afterward