### PR TITLE
Fix #4738: skip CanCreate existence check for singleton resources

### DIFF
--- a/provider/pkg/provider/crud/crud.go
+++ b/provider/pkg/provider/crud/crud.go
@@ -408,6 +408,13 @@ func (r *resourceCrudClient) SdkInputsToRequestBody(properties map[string]any, i
 }
 
 func (r *resourceCrudClient) CanCreate(ctx context.Context, id string) error {
+	if r.res.Singleton {
+		// Singleton resources have no DELETE operation and always exist once their parent
+		// does, so the existence check is unnecessary. Skipping it also avoids spurious
+		// failures (e.g. a transient 400 AuthenticationFailed) while ARM's auth context is
+		// still propagating for a just-recreated parent. See issue #4738.
+		return nil
+	}
 	return r.azureClient.CanCreate(ctx, id, r.res.ReadPath, r.res.APIVersion, r.res.ReadMethod, r.res.Singleton, r.res.DefaultBody != nil, func(outputs map[string]any) bool {
 		return r.converter.IsDefaultResponse(r.res.PutParameters, outputs, r.res.DefaultBody)
 	})

--- a/provider/pkg/provider/crud/crud_test.go
+++ b/provider/pkg/provider/crud/crud_test.go
@@ -262,6 +262,27 @@ func TestCanCreate_RequestUrls(t *testing.T) {
 	})
 }
 
+// TestCanCreateSkipsNetworkCallForSingleton is a regression test for issue #4738: CanCreate must
+// not make a network call for singleton resources, since a singleton always exists once its
+// parent does and the network round trip only exposes a window for transient/unexpected ARM
+// errors (e.g. a 400 AuthenticationFailed while auth context propagates for a just-recreated
+// parent) to wrongly abort creation.
+func TestCanCreateSkipsNetworkCallForSingleton(t *testing.T) {
+	res := &resources.AzureAPIResource{Singleton: true}
+
+	called := false
+	client, err := azure.CreateTestClient(t, func(t *testing.T, req *http.Request) {
+		called = true
+	})
+	require.NoError(t, err)
+
+	crudClient := NewResourceCrudClient(client, nil, nil, "123", res)
+	err = crudClient.CanCreate(context.Background(), "/subscriptions/123/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa/fileServices/default")
+
+	assert.NoError(t, err)
+	assert.False(t, called, "CanCreate should not make a network call for singleton resources")
+}
+
 func TestSqlVirtualMachineUsesReadQueryParams(t *testing.T) {
 	sqlVmResource := resources.AzureAPIResource{
 		Path:            "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}",

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -538,6 +538,26 @@ func TestDatabricksWorkspaceComputeModeDefault(t *testing.T) {
 		"expected a replacement when changing computeMode from Hybrid to Serverless")
 }
 
+// TestStorageAccountSingletonChildAfterReplace is a regression test for issue #4738: replacing a
+// StorageAccount (e.g. changing the immutable isHnsEnabled property) cascades into a
+// delete-then-create of its FileServiceProperties singleton child. That child's Create call used
+// to run an existence check that could transiently fail with 400 AuthenticationFailed while
+// ARM's auth context propagated for the newly recreated account. CanCreate now skips that check
+// for singleton resources, since a singleton always exists once its parent does.
+func TestStorageAccountSingletonChildAfterReplace(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "storage-sa-replace-singleton-child/step1")
+	defer func() {
+		pt.Destroy(t)
+	}()
+
+	pt.Up(t)
+
+	// Removing isHnsEnabled forces the replace; pt.Up fails the test on any error.
+	pt.UpdateSource(t, "test-programs", "storage-sa-replace-singleton-child", "step2")
+	pt.Up(t)
+}
+
 func upgradeTest(t *testing.T, testProgramDir string, upgradeFromVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) {
 	t.Helper()
 	if testing.Short() {

--- a/provider/pkg/provider/test-programs/storage-sa-replace-singleton-child/step1/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/storage-sa-replace-singleton-child/step1/Pulumi.yaml
@@ -1,0 +1,34 @@
+name: storage-sa-replace-singleton-child
+runtime: yaml
+description: |
+  Regression test for issue #4738: after a StorageAccount is replaced (deleted, then
+  recreated under the same physical name -- triggered here by changing the immutable
+  isHnsEnabled property), singleton child resources like FileServiceProperties can fail
+  with a transient 400 AuthenticationFailed because CanCreate performs an unnecessary
+  existence check against the just-recreated account before ARM's auth context has fully
+  propagated. step1: create the account with isHnsEnabled explicitly set to false, plus
+  its FileServiceProperties singleton child.
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  store:
+    type: azure-native:storage:StorageAccount
+    properties:
+      accountName: sa${rg.name}
+      resourceGroupName: ${rg.name}
+      location: ${rg.location}
+      kind: StorageV2
+      isHnsEnabled: false
+      sku:
+        name: Standard_LRS
+    options:
+      deleteBeforeReplace: true
+
+  fileService:
+    type: azure-native:storage:FileServiceProperties
+    properties:
+      resourceGroupName: ${rg.name}
+      accountName: ${store.name}
+      fileServicesName: default

--- a/provider/pkg/provider/test-programs/storage-sa-replace-singleton-child/step2/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/storage-sa-replace-singleton-child/step2/Pulumi.yaml
@@ -1,0 +1,32 @@
+name: storage-sa-replace-singleton-child
+runtime: yaml
+description: |
+  step2: remove isHnsEnabled from the StorageAccount definition. isHnsEnabled is
+  ForceNew, so this forces a replace of the account (same physical name, deleted
+  then recreated). The FileServiceProperties singleton child cascades into its own
+  delete-then-create even though its own inputs are unchanged, racing the Create
+  call's CanCreate existence check against ARM's auth-context propagation delay
+  for the newly recreated account.
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  store:
+    type: azure-native:storage:StorageAccount
+    properties:
+      accountName: sa${rg.name}
+      resourceGroupName: ${rg.name}
+      location: ${rg.location}
+      kind: StorageV2
+      sku:
+        name: Standard_LRS
+    options:
+      deleteBeforeReplace: true
+
+  fileService:
+    type: azure-native:storage:FileServiceProperties
+    properties:
+      resourceGroupName: ${rg.name}
+      accountName: ${store.name}
+      fileServicesName: default


### PR DESCRIPTION
## Summary
- Reproduced #4738 live against Azure: replacing a `StorageAccount` (e.g. removing the immutable `isHnsEnabled` property) cascades into a delete-then-create of its `FileServiceProperties` singleton child, whose `CanCreate` existence check transiently failed with `400 AuthenticationFailed` while ARM's auth context propagated for the newly recreated account.
- Applied the fix proposed in the issue: `resourceCrudClient.CanCreate` now returns `nil` immediately for singleton resources instead of making the network call. This is safe because the existing low-level `CanCreate` already treats singleton 200/404 as unconditional success — the only way it could error for a singleton was an unexpected/transient status (like this 400), which skipping the call removes entirely.
- Re-ran the live repro after the fix: both deploys now succeed cleanly with no `CanCreate`/`AuthenticationFailed` error.
- Added `TestCanCreateSkipsNetworkCallForSingleton` (unit) asserting no network call happens for singletons, and `TestStorageAccountSingletonChildAfterReplace` (live e2e) reproducing the replace scenario end-to-end.

## Test plan
- [x] `go test ./pkg/provider/crud/... ./pkg/azure/...` (unit tests pass)
- [x] `TestStorageAccountSingletonChildAfterReplace` run live against Azure: fails before the fix with the exact reported error, passes after
- [x] Verified no leftover Azure resources after test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)