### PR TITLE
Fix #4772: diff ManagedCluster.backendPoolType case-insensitively

### DIFF
--- a/provider/pkg/gen/properties.go
+++ b/provider/pkg/gen/properties.go
@@ -448,6 +448,7 @@ func (m *moduleGenerator) genProperty(name string, schema *spec.Schema, context 
 		IsStringSet:                         isStringSet,
 		Default:                             defaultValue,
 		MaintainSubResourceIfUnset:          maintainSubResourceIfUnset,
+		CaseInsensitive:                     m.caseInsensitiveDiff(name),
 	}
 
 	if identifiers, ok := schema.Extensions.GetStringSlice(extensionIdentifiers); ok && typeSpec.Type == "array" {
@@ -458,9 +459,10 @@ func (m *moduleGenerator) genProperty(name string, schema *spec.Schema, context 
 	if !variants.isOutput {
 		if m.isEnum(&schemaProperty.TypeSpec) {
 			metadataProperty = resources.AzureAPIProperty{
-				Type:     "string",
-				Default:  defaultValue,
-				ForceNew: forceNewSpec == forceNew,
+				Type:            "string",
+				Default:         defaultValue,
+				ForceNew:        forceNewSpec == forceNew,
+				CaseInsensitive: m.caseInsensitiveDiff(name),
 			}
 		} else {
 			// Set additional properties when it's an input
@@ -594,6 +596,17 @@ func (m *moduleGenerator) enumOverride(propertyName string) (EnumOverride, bool)
 // notRequiredInputsMap.
 func (m *moduleGenerator) notRequired(propertyName string) bool {
 	if resourceMap, ok := notRequiredInputsMap[m.moduleName]; ok {
+		if properties, ok := resourceMap[m.resourceName]; ok {
+			return properties.Has(propertyName)
+		}
+	}
+	return false
+}
+
+// caseInsensitiveDiff returns true if propertyName's string values should be diffed
+// case-insensitively on the resource currently being generated, per caseInsensitiveDiffMap.
+func (m *moduleGenerator) caseInsensitiveDiff(propertyName string) bool {
+	if resourceMap, ok := caseInsensitiveDiffMap[m.moduleName]; ok {
 		if properties, ok := resourceMap[m.resourceName]; ok {
 			return properties.Has(propertyName)
 		}

--- a/provider/pkg/gen/properties_test.go
+++ b/provider/pkg/gen/properties_test.go
@@ -103,6 +103,17 @@ func TestForceNew(t *testing.T) {
 	})
 }
 
+func TestCaseInsensitiveDiff(t *testing.T) {
+	managedCluster := moduleGenerator{moduleName: "ContainerService", resourceName: "ManagedCluster"}
+	otherResource := moduleGenerator{moduleName: "ContainerService", resourceName: "AgentPool"}
+	otherModule := moduleGenerator{moduleName: "Storage", resourceName: "StorageAccount"}
+
+	assert.True(t, managedCluster.caseInsensitiveDiff("backendPoolType"))
+	assert.False(t, managedCluster.caseInsensitiveDiff("someOtherProperty"))
+	assert.False(t, otherResource.caseInsensitiveDiff("backendPoolType"))
+	assert.False(t, otherModule.caseInsensitiveDiff("backendPoolType"))
+}
+
 func TestIsReadableOutput(t *testing.T) {
 	webApp := moduleGenerator{moduleName: "Web", resourceName: "WebApp"}
 	webAppSlot := moduleGenerator{moduleName: "Web", resourceName: "WebAppSlot"}

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -116,6 +116,19 @@ var noForceNewMap = map[openapi.ModuleName]map[string]codegen.StringSet{
 	},
 }
 
+// caseInsensitiveDiffMap is a map of Module Name -> Resource Name -> input properties whose string
+// values should be diffed case-insensitively. Only add an entry here after confirming that Azure
+// treats the property's values as case-insensitive but echoes back a different casing than what was
+// sent (verified against a live resource, not just the spec). See
+// https://github.com/pulumi/pulumi-azure-native/issues/4772: ManagedCluster's networkProfile.
+// loadBalancerProfile.backendPoolType resolves to "NodeIPConfiguration" in the spec/SDK enum, but
+// the AKS RP always returns "nodeIPConfiguration", producing a spurious diff.
+var caseInsensitiveDiffMap = map[openapi.ModuleName]map[string]codegen.StringSet{
+	"ContainerService": {
+		"ManagedCluster": codegen.NewStringSet("backendPoolType"),
+	},
+}
+
 // notRequiredInputsMap is a map of Module Name -> Resource Name -> input properties that the
 // OpenAPI spec marks as required, but that we keep optional in the generated SDK. Only add an
 // entry here after directly verifying (e.g. via a raw ARM REST call or ARM template deployment)

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -200,6 +200,11 @@ func valueDiff(properties map[string]resources.AzureAPIProperty,
 		if stringsEqualCaseInsensitiveAzureIds(old.StringValue(), new.StringValue()) {
 			return nil
 		}
+		if prop, ok := properties[path]; ok && prop.CaseInsensitive {
+			if strings.EqualFold(old.StringValue(), new.StringValue()) {
+				return nil
+			}
+		}
 	}
 
 	// If we got here, either the values are primitives, or they weren't the same type; do a simple diff.

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -638,6 +638,88 @@ func TestSkuDiffingIsInsensitiveToAksPermutations(t *testing.T) {
 	}
 }
 
+// TestManagedClusterBackendPoolTypeDiffingIsCaseInsensitive is a regression test for
+// https://github.com/pulumi/pulumi-azure-native/issues/4772: the spec/SDK enum for
+// networkProfile.loadBalancerProfile.backendPoolType resolves to "NodeIPConfiguration", but the AKS RP
+// always echoes back "nodeIPConfiguration", which produced a permanent spurious diff (and, prior to
+// #4756, a full cluster replacement). Only backendPoolType is marked CaseInsensitive; a sibling property
+// must still diff normally, proving the exception is scoped to that one property.
+func TestManagedClusterBackendPoolTypeDiffingIsCaseInsensitive(t *testing.T) {
+	const networkProfileRef = "#/types/azure-native:containerservice:ContainerServiceNetworkProfile"
+	const loadBalancerProfileRef = "#/types/azure-native:containerservice:ManagedClusterLoadBalancerProfile"
+
+	res := resources.AzureAPIResource{
+		PutParameters: []resources.AzureAPIParameter{
+			{
+				Location: "body",
+				Name:     "bodyProperties",
+				Body: &resources.AzureAPIType{
+					Properties: map[string]resources.AzureAPIProperty{
+						"networkProfile": {Ref: networkProfileRef},
+					},
+				},
+			},
+		},
+	}
+
+	lookupType := func(ref string) (*resources.AzureAPIType, bool, error) {
+		switch ref {
+		case networkProfileRef:
+			return &resources.AzureAPIType{
+				Properties: map[string]resources.AzureAPIProperty{
+					"loadBalancerProfile": {Ref: loadBalancerProfileRef},
+				},
+			}, true, nil
+		case loadBalancerProfileRef:
+			return &resources.AzureAPIType{
+				Properties: map[string]resources.AzureAPIProperty{
+					"backendPoolType": {Type: "string", CaseInsensitive: true},
+					"outboundType":    {Type: "string"},
+				},
+			}, true, nil
+		}
+		return nil, false, nil
+	}
+
+	loadBalancerProfileInputs := func(backendPoolType, outboundType string) resource.PropertyMap {
+		return resource.PropertyMap{
+			"networkProfile": {V: resource.PropertyMap{
+				"loadBalancerProfile": {V: resource.PropertyMap{
+					"backendPoolType": {V: backendPoolType},
+					"outboundType":    {V: outboundType},
+				}},
+			}},
+		}
+	}
+
+	t.Run("casing-only difference is not a diff", func(t *testing.T) {
+		oldInputs := loadBalancerProfileInputs("nodeIPConfiguration", "loadBalancer")
+		newInputs := loadBalancerProfileInputs("NodeIPConfiguration", "loadBalancer")
+		actual := diff(lookupType, res, oldInputs, newInputs)
+		assert.Nil(t, actual)
+	})
+
+	t.Run("a genuine value change still diffs", func(t *testing.T) {
+		oldInputs := loadBalancerProfileInputs("nodeIPConfiguration", "loadBalancer")
+		newInputs := loadBalancerProfileInputs("userDefinedRouting", "loadBalancer")
+		actual := diff(lookupType, res, oldInputs, newInputs)
+		expected := map[string]*rpc.PropertyDiff{
+			"networkProfile.loadBalancerProfile.backendPoolType": {Kind: rpc.PropertyDiff_UPDATE},
+		}
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("casing difference on a sibling property without the exception still diffs", func(t *testing.T) {
+		oldInputs := loadBalancerProfileInputs("nodeIPConfiguration", "loadBalancer")
+		newInputs := loadBalancerProfileInputs("nodeIPConfiguration", "LoadBalancer")
+		actual := diff(lookupType, res, oldInputs, newInputs)
+		expected := map[string]*rpc.PropertyDiff{
+			"networkProfile.loadBalancerProfile.outboundType": {Kind: rpc.PropertyDiff_UPDATE},
+		}
+		assert.Equal(t, expected, actual)
+	})
+}
+
 var emptyTypes resources.TypeLookupFunc = func(t string) (*resources.AzureAPIType, bool, error) {
 	return nil, false, nil
 }

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -89,6 +89,10 @@ type AzureAPIProperty struct {
 	// Optional. Properties that combined form a unique identifier for elements in this array.
 	// Corresponds to the x-ms-identifiers extension in the Azure spec.
 	ArrayIdentifiers []string `json:"arrayIdentifiers,omitempty"`
+	// Whether string values of this property should be compared case-insensitively when diffing.
+	// Set for specific enum-typed properties (see caseInsensitiveDiffMap) where Azure is known to
+	// echo back a value that only differs from what was sent in casing.
+	CaseInsensitive bool `json:"caseInsensitive,omitempty"`
 }
 
 // AzureAPIType represents the shape of an object property.


### PR DESCRIPTION
## Summary
- `networkProfile.loadBalancerProfile.backendPoolType` on `ManagedCluster` resolves to `NodeIPConfiguration` per the spec/SDK enum, but the AKS RP always echoes back `nodeIPConfiguration`, producing a spurious diff whenever recorded state casing doesn't match the program (e.g. after import/migration).
- Adds a `caseInsensitiveDiffMap` (mirroring the existing `forceNewMap` pattern) that marks specific enum properties as case-insensitive for diffing. Scoped to just this one property/resource rather than generalized to all enums, since we haven't verified that's safe more broadly.

Fixes #4772

## Test plan
- [x] Unit tests in `diff_test.go` and `properties_test.go` covering the new mechanism (including that sibling properties/resources are unaffected)
- [x] Verified the flag lands correctly in real generated metadata across all 61 API versions of `ManagedCluster` that have `backendPoolType`
- [x] Verified `make generate_docs` / `make generate` produce no SDK changes (the flag only affects provider-side diffing metadata)
- [x] Verified live against a real AKS cluster: creating with the lowercase wire value then switching the program to the spec casing produces zero diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)