### PR TITLE
Fix #4782: don't send siteConfig.http20ProxyFlag's spec default of 0

### DIFF
--- a/provider/pkg/gen/properties.go
+++ b/provider/pkg/gen/properties.go
@@ -414,6 +414,13 @@ func (m *moduleGenerator) genProperty(name string, schema *spec.Schema, context 
 		}
 	}
 
+	// Some spec-declared defaults are values Azure itself rejects, so drop them and leave the
+	// property unset unless the user assigns it explicitly (see noDefaultMap).
+	if defaultValue != nil && m.noDefault(name) {
+		logging.V(5).Infof("Dropping default value '%v' for property %q per noDefaultMap\n", defaultValue, name)
+		defaultValue = nil
+	}
+
 	// If there's no object value type, then it's just a set of strings which we'll represent as a string
 	// array in the SDK, but leave the metadata to indicate we need to convert it.
 	isStringSet := typeSpec.Type == "object" && typeSpec.AdditionalProperties == nil && typeSpec.Ref == ""
@@ -596,6 +603,17 @@ func (m *moduleGenerator) enumOverride(propertyName string) (EnumOverride, bool)
 // notRequiredInputsMap.
 func (m *moduleGenerator) notRequired(propertyName string) bool {
 	if resourceMap, ok := notRequiredInputsMap[m.moduleName]; ok {
+		if properties, ok := resourceMap[m.resourceName]; ok {
+			return properties.Has(propertyName)
+		}
+	}
+	return false
+}
+
+// noDefault returns true if the OpenAPI spec's default value for propertyName should be dropped
+// on the resource currently being generated, per noDefaultMap.
+func (m *moduleGenerator) noDefault(propertyName string) bool {
+	if resourceMap, ok := noDefaultMap[m.moduleName]; ok {
 		if properties, ok := resourceMap[m.resourceName]; ok {
 			return properties.Has(propertyName)
 		}

--- a/provider/pkg/gen/properties_test.go
+++ b/provider/pkg/gen/properties_test.go
@@ -114,6 +114,20 @@ func TestCaseInsensitiveDiff(t *testing.T) {
 	assert.False(t, otherModule.caseInsensitiveDiff("backendPoolType"))
 }
 
+func TestNoDefault(t *testing.T) {
+	webApp := moduleGenerator{moduleName: "Web", resourceName: "WebApp"}
+	webAppSlot := moduleGenerator{moduleName: "Web", resourceName: "WebAppSlot"}
+	otherResource := moduleGenerator{moduleName: "Web", resourceName: "AppServicePlan"}
+	otherModule := moduleGenerator{moduleName: "Storage", resourceName: "StorageAccount"}
+
+	assert.True(t, webApp.noDefault("http20ProxyFlag"))
+	assert.True(t, webAppSlot.noDefault("http20ProxyFlag"))
+	// Sibling properties of the same type keep their spec defaults.
+	assert.False(t, webApp.noDefault("http20Enabled"))
+	assert.False(t, otherResource.noDefault("http20ProxyFlag"))
+	assert.False(t, otherModule.noDefault("http20ProxyFlag"))
+}
+
 func TestIsReadableOutput(t *testing.T) {
 	webApp := moduleGenerator{moduleName: "Web", resourceName: "WebApp"}
 	webAppSlot := moduleGenerator{moduleName: "Web", resourceName: "WebAppSlot"}

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -129,6 +129,28 @@ var caseInsensitiveDiffMap = map[openapi.ModuleName]map[string]codegen.StringSet
 	},
 }
 
+// noDefaultMap is a map of Module Name -> Resource Name -> properties whose spec-declared `default`
+// should be dropped from the generated schema, so the SDKs leave the property out of the request
+// body unless the user assigns it explicitly. Only add an entry here after confirming that Azure
+// rejects (or misbehaves on) receiving the spec's own default value, i.e. that the spec documents a
+// default the RP won't actually accept on the wire for every flavour of the resource.
+var noDefaultMap = map[openapi.ModuleName]map[string]codegen.StringSet{
+	"Web": {
+		// siteConfig.http20ProxyFlag was added to Microsoft.Web/sites in API version 2024-11-01
+		// with a spec default of 0, which the SDKs then send on every request. Azure Functions on
+		// Azure Container Apps rejects the property outright ("Http20ProxyFlag is not supported for
+		// Azure Functions on Azure Container apps"), so apps with kind
+		// `functionapp,linux,container,azurecontainerapps` started failing to create as soon as the
+		// provider's default Web API version moved past 2024-11-01. Users can't work around it
+		// because an unset (null) input is indistinguishable from an omitted one. See
+		// https://github.com/pulumi/pulumi-azure-native/issues/4782.
+		// Both resources that embed SiteConfig are listed because the type is generated once and
+		// whichever resource's pass reaches it first fixes its shape for both.
+		"WebApp":     codegen.NewStringSet("http20ProxyFlag"),
+		"WebAppSlot": codegen.NewStringSet("http20ProxyFlag"),
+	},
+}
+
 // notRequiredInputsMap is a map of Module Name -> Resource Name -> input properties that the
 // OpenAPI spec marks as required, but that we keep optional in the generated SDK. Only add an
 // entry here after directly verifying (e.g. via a raw ARM REST call or ARM template deployment)

--- a/sdk/dotnet/Web/Inputs/SiteConfigArgs.cs
+++ b/sdk/dotnet/Web/Inputs/SiteConfigArgs.cs
@@ -510,7 +510,6 @@ namespace Pulumi.AzureNative.Web.Inputs
         public SiteConfigArgs()
         {
             Http20Enabled = true;
-            Http20ProxyFlag = 0;
             LocalMySqlEnabled = false;
             NetFrameworkVersion = "v4.6";
         }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -183931,7 +183931,6 @@ export namespace web {
         return {
             ...val,
             http20Enabled: (val.http20Enabled) ?? true,
-            http20ProxyFlag: (val.http20ProxyFlag) ?? 0,
             localMySqlEnabled: (val.localMySqlEnabled) ?? false,
             netFrameworkVersion: (val.netFrameworkVersion) ?? "v4.6",
         };

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -254272,7 +254272,6 @@ export namespace web {
         return {
             ...val,
             http20Enabled: (val.http20Enabled) ?? true,
-            http20ProxyFlag: (val.http20ProxyFlag) ?? 0,
             localMySqlEnabled: (val.localMySqlEnabled) ?? false,
             netFrameworkVersion: (val.netFrameworkVersion) ?? "v4.6",
         };

--- a/sdk/python/pulumi_azure_native/web/_inputs.py
+++ b/sdk/python/pulumi_azure_native/web/_inputs.py
@@ -10505,8 +10505,6 @@ class SiteConfigArgs:
             http20_enabled = True
         if http20_enabled is not None:
             pulumi.set(__self__, "http20_enabled", http20_enabled)
-        if http20_proxy_flag is None:
-            http20_proxy_flag = 0
         if http20_proxy_flag is not None:
             pulumi.set(__self__, "http20_proxy_flag", http20_proxy_flag)
         if http_logging_enabled is not None:

--- a/sdk/python/pulumi_azure_native/web/outputs.py
+++ b/sdk/python/pulumi_azure_native/web/outputs.py
@@ -9258,8 +9258,6 @@ class SiteConfigResponse(dict):
             http20_enabled = True
         if http20_enabled is not None:
             pulumi.set(__self__, "http20_enabled", http20_enabled)
-        if http20_proxy_flag is None:
-            http20_proxy_flag = 0
         if http20_proxy_flag is not None:
             pulumi.set(__self__, "http20_proxy_flag", http20_proxy_flag)
         if http_logging_enabled is not None:


### PR DESCRIPTION
## Summary
- `siteConfig.http20ProxyFlag` on `WebApp`/`WebAppSlot` carries an OpenAPI spec default of `0`, which every SDK then sent on create/update even when the user left the property unset.
- Azure Functions on Container Apps (kind `functionapp,linux,container,azurecontainerapps`) rejects the property outright, so those apps failed to deploy with a `Http20ProxyFlag is invalid` 400 error, and users had no workaround since an explicit `null` input is indistinguishable from an omitted one.
- Adds a `noDefaultMap` in `provider/pkg/gen/replacement.go` (parallel to the existing `caseInsensitiveDiffMap` pattern) so specific module/resource/property combos can have their spec-declared default dropped during codegen, and wires it into `properties.go`. Scoped to `Web.WebApp`/`Web.WebAppSlot` `http20ProxyFlag` only — no change to default-handling behavior elsewhere.
- Regenerated the docs schema and Node.js/Python/.NET SDKs to drop the `0` default for this property.

Fixes #4782.

## Test plan
- [x] `go test ./provider/pkg/gen/...` passes, including new `TestNoDefault` unit test
- [x] `go build ./...` succeeds for the provider
- [x] Verified regenerated schema/SDK diffs are scoped to `http20ProxyFlag`'s default only (schema.json, dotnet `SiteConfigArgs.cs`, nodejs `input.ts`/`output.ts`, python `_inputs.py`/`outputs.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)