### PR TITLE
Update pulumi/pulumi sdk to v3.256.0 in the Go SDK go.mod template

### DIFF
--- a/provider/cmd/pulumi-gen-azure-native/main.go
+++ b/provider/cmd/pulumi-gen-azure-native/main.go
@@ -324,7 +324,7 @@ require (
 {{ if ne .SubmoduleName "" }}
 	github.com/pulumi/pulumi-azure-native-sdk{{ .ModuleVersionPath }} {{ .Version }}
 {{ end }}
-	github.com/pulumi/pulumi/sdk/v3 v3.253.0
+	github.com/pulumi/pulumi/sdk/v3 v3.256.0
 )
 
 {{ if ne .SubmoduleName "" }}


### PR DESCRIPTION
Downstream codegen will depend on a change first released in pulumi v3.256.0, so the go.mod files emitted into [pulumi-azure-native-sdk](https://github.com/pulumi/pulumi-azure-native-sdk) must require at least that version.

The pin is hardcoded in the `goModTemplate` of `pulumi-gen-azure-native`; this takes effect in the mirror repo at the next SDK release. Replaces pulumi/pulumi-azure-native-sdk#63, which edited the generated mirror directly and would have been overwritten by the publish workflow.