### PR TITLE
Fix #1684: search.Service hostingMode diffs case-insensitively

### DIFF
--- a/provider/pkg/gen/properties_test.go
+++ b/provider/pkg/gen/properties_test.go
@@ -112,6 +112,10 @@ func TestCaseInsensitiveDiff(t *testing.T) {
 	assert.False(t, managedCluster.caseInsensitiveDiff("someOtherProperty"))
 	assert.False(t, otherResource.caseInsensitiveDiff("backendPoolType"))
 	assert.False(t, otherModule.caseInsensitiveDiff("backendPoolType"))
+
+	searchService := moduleGenerator{moduleName: "Search", resourceName: "Service"}
+	assert.True(t, searchService.caseInsensitiveDiff("hostingMode"))
+	assert.False(t, searchService.caseInsensitiveDiff("someOtherProperty"))
 }
 
 func TestNoDefault(t *testing.T) {

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -127,6 +127,12 @@ var caseInsensitiveDiffMap = map[openapi.ModuleName]map[string]codegen.StringSet
 	"ContainerService": {
 		"ManagedCluster": codegen.NewStringSet("backendPoolType"),
 	},
+	"Search": {
+		// hostingMode resolves to "Default"/"HighDensity" in the spec/SDK enum, but the Search RP
+		// always returns "default"/"highDensity" (lowercase), producing a spurious diff on the very
+		// first deploy or import. See https://github.com/pulumi/pulumi-azure-native/issues/1684.
+		"Service": codegen.NewStringSet("hostingMode"),
+	},
 }
 
 // noDefaultMap is a map of Module Name -> Resource Name -> properties whose spec-declared `default`


### PR DESCRIPTION
Closes #1684.
Closes #3220 by extension

`hostingMode` is capitalized (`Default`/`HighDensity`) in the spec/SDK enum, but Azure always echoes it back lowercased — verified live, even a PATCH sending `Default` reads back as `default`. Adds `search.Service.hostingMode` to `caseInsensitiveDiffMap`, the same mechanism used for AKS's `backendPoolType` (#4772).

`location` and `publicNetworkAccess`, the other two fields from the original report, are already fixed (location has a generic case/space-insensitive diff; the spec now matches ARM's casing for publicNetworkAccess) — confirmed by reproducing against a live Search Service imported into a fresh stack.

## Test plan
- [x] `go test ./pkg/gen/...` — new/existing case-insensitive-diff unit tests pass
- [x] `go test ./pkg/provider/...` — generic case-insensitive diff regression tests pass (pre-existing `TestParameterizePackageAdd` failure is an unrelated local env issue, missing `yarn`)
- [x] Deployed a real `Microsoft.Search/searchServices` via ARM template, imported into Pulumi, confirmed `hostingMode` metadata now carries `caseInsensitive: true` after regenerating the schema