### PR TITLE
Fix #4408: WebAppBackupConfiguration always shows as create on refresh

### DIFF
--- a/provider/pkg/azure/client.go
+++ b/provider/pkg/azure/client.go
@@ -41,6 +41,8 @@ type MockAzureClient struct {
 	// Bodies that were sent via Put, in order
 	PutBodies []map[string]any
 
+	// If set, this response will be returned for all Put requests; otherwise nil.
+	PutResponse    map[string]any
 	PutResponseErr error
 
 	QueryParamsOfLastDelete map[string]any
@@ -73,7 +75,7 @@ func (m *MockAzureClient) Post(ctx context.Context, id string, bodyProps map[str
 func (m *MockAzureClient) Put(ctx context.Context, id string, bodyProps map[string]interface{}, queryParameters map[string]interface{}, asyncStyle string) (map[string]interface{}, bool, error) {
 	m.PutIds = append(m.PutIds, id)
 	m.PutBodies = append(m.PutBodies, bodyProps)
-	return nil, false, m.PutResponseErr
+	return m.PutResponse, false, m.PutResponseErr
 }
 func (m *MockAzureClient) IsNotFound(err error) bool {
 	return false

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -1253,6 +1253,7 @@ func (g *packageGenerator) genResourceVariant(apiSpec *openapi.ResourceSpec, res
 		ReadPath:              readPath,
 		ReadQueryParams:       readUrlParams,
 		AutoLocationDisabled:  resources.AutoLocationDisabled(resource.Path),
+		IgnoreResponseID:      resources.IgnoreResponseID(resource.Path),
 		RequiredContainers:    requiredContainers,
 		DefaultProperties:     propertyDefaults(module, resource.typeName),
 		ApiVersionIsUserInput: apiVersionIsUserInput(string(g.moduleName), resource.typeName),

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1396,7 +1396,7 @@ func (k *azureNativeProvider) Create(ctx context.Context, req *rpc.CreateRequest
 		}
 
 		id, outputs, err = k.defaultCreate(ctx, req, inputs, id, queryParams, crudClient,
-			reader(customRes, crudClient, inputsForRead))
+			reader(customRes, crudClient, inputsForRead), res.IgnoreResponseID)
 		if err != nil {
 			return nil, err
 		}
@@ -1451,7 +1451,7 @@ func customCreate(ctx context.Context, inputs resource.PropertyMap, id string, c
 }
 
 func (k *azureNativeProvider) defaultCreate(ctx context.Context, req *rpc.CreateRequest, inputs resource.PropertyMap, id string,
-	queryParams map[string]any, crudClient crud.ResourceCrudClient, reader readFunc) (string, map[string]any, error) {
+	queryParams map[string]any, crudClient crud.ResourceCrudClient, reader readFunc, ignoreResponseID bool) (string, map[string]any, error) {
 	bodyParams, err := crudClient.PrepareAzureRESTBody(id, inputs, nil)
 	if err != nil {
 		bodyError := fmt.Errorf("error preparing body for %s: %v", id, err)
@@ -1478,9 +1478,13 @@ func (k *azureNativeProvider) defaultCreate(ctx context.Context, req *rpc.Create
 		return id, nil, azure.AzureError(err)
 	}
 
-	// Read the canonical ID from the response.
-	if azureId, ok := response["id"].(string); ok {
-		id = azureId
+	// Read the canonical ID from the response, unless this resource's response id is known not to
+	// be trustworthy (e.g. singleton config sub-resources whose PUT response returns their parent's
+	// id instead of their own, see resources.IgnoreResponseID).
+	if !ignoreResponseID {
+		if azureId, ok := response["id"].(string); ok {
+			id = azureId
+		}
 	}
 
 	if readResponse := k.readAfterWrite(ctx, id, req.GetUrn(), "Create", inputs, reader); readResponse != nil {

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -177,6 +177,33 @@ func TestGenericResourceCreatingCongitiveServicesAccount(t *testing.T) {
 	assert.NotContainsf(t, upResult.StdOut, errorMsg, "Expected not to see error message '%s' in stderr", errorMsg)
 }
 
+// TestWebAppBackupConfiguration guards against issue #4408: Azure's PUT response for this resource
+// returns the parent site's id rather than the backup config's own id, which used to get adopted as
+// the resource's canonical ID (see resources.IgnoreResponseID) and broke the subsequent read.
+func TestWebAppBackupConfiguration(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "webapp-backup-configuration")
+	defer func() {
+		pt.Destroy(t)
+	}()
+
+	up := pt.Up(t)
+	errorMsg := "Failed to read resource after Create. Please report this issue."
+	assert.NotContainsf(t, up.StdOut, errorMsg, "Expected not to see error message %q in stdout", errorMsg)
+
+	backupConfigId, ok := up.Outputs["backupConfigId"].Value.(string)
+	require.True(t, ok)
+	assert.Contains(t, backupConfigId, "/config/backup")
+
+	assertrefresh.HasNoChanges(t, pt.Refresh(t))
+
+	// A second Up must be a no-op: the bug caused refresh/preview to always see a new create.
+	up2 := pt.Up(t)
+	upSummary := changesummary.FromStringIntMap(*up2.Summary.ResourceChanges)
+	assert.Zero(t, upSummary[apitype.OpCreate], "expected no creates on a repeat up")
+	assert.Zero(t, upSummary[apitype.OpUpdate], "expected no updates on a repeat up")
+}
+
 func TestAutonaming(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "autonaming", opttest.Env("PULUMI_EXPERIMENTAL", "1"))

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -747,6 +747,41 @@ func TestReadAfterWrite(t *testing.T) {
 	}
 }
 
+// TestDefaultCreateIgnoreResponseID guards against issue #4408: Azure's PUT response for some
+// resources (e.g. singleton "config" sub-resources under Microsoft.Web sites) returns the parent
+// resource's id rather than their own. defaultCreate must not adopt that id as canonical when
+// resources.IgnoreResponseID is set for the resource's path.
+func TestDefaultCreateIgnoreResponseID(t *testing.T) {
+	const (
+		constructedID = "/subscriptions/123/resourceGroups/rg/providers/Microsoft.Web/sites/site1/config/backup"
+		parentID      = "/subscriptions/123/resourceGroups/rg/providers/Microsoft.Web/sites/site1"
+	)
+
+	for _, tt := range []struct {
+		name             string
+		ignoreResponseID bool
+		expectedID       string
+	}{
+		{name: "adopts response id by default", ignoreResponseID: false, expectedID: parentID},
+		{name: "keeps constructed id when ignored", ignoreResponseID: true, expectedID: constructedID},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res := &resources.AzureAPIResource{}
+			azureClient := &az.MockAzureClient{
+				PutResponse: map[string]any{"id": parentID},
+			}
+			crudClient := crud.NewResourceCrudClient(azureClient, nil, &convert.SdkShapeConverter{}, "123", res)
+
+			k := &azureNativeProvider{skipReadOnUpdate: true}
+			id, _, err := k.defaultCreate(context.Background(), &rpc.CreateRequest{}, resource.PropertyMap{},
+				constructedID, nil, crudClient, nil, tt.ignoreResponseID)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedID, id)
+		})
+	}
+}
+
 func TestAzcoreAzureClientUsesCorrectCloud(t *testing.T) {
 	for expectedHost, cloudInstance := range map[string]cloud.Configuration{
 		"https://management.azure.com":         cloud.AzurePublic,

--- a/provider/pkg/provider/test-programs/webapp-backup-configuration/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/webapp-backup-configuration/Pulumi.yaml
@@ -1,0 +1,57 @@
+name: webapp-backup-configuration
+runtime: yaml
+description: Repro for issue #4408 - WebAppBackupConfiguration always shows as create on refresh
+variables:
+  sasToken:
+    fn::invoke:
+      function: azure-native:storage:listStorageAccountSAS
+      arguments:
+        resourceGroupName: ${rg.name}
+        accountName: ${storage.name}
+        permissions: "rwdlacu"
+        resourceTypes: "sco"
+        services: "b"
+        sharedAccessExpiryTime: "2030-01-01T00:00:00Z"
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+  storage:
+    type: azure-native:storage:StorageAccount
+    properties:
+      resourceGroupName: ${rg.name}
+      kind: StorageV2
+      sku:
+        name: Standard_LRS
+  backupContainer:
+    type: azure-native:storage:BlobContainer
+    properties:
+      resourceGroupName: ${rg.name}
+      accountName: ${storage.name}
+      containerName: "backups"
+  plan:
+    type: azure-native:web:AppServicePlan
+    properties:
+      resourceGroupName: ${rg.name}
+      kind: "app"
+      sku:
+        name: "S1"
+        tier: "Standard"
+  app:
+    type: azure-native:web:WebApp
+    properties:
+      resourceGroupName: ${rg.name}
+      serverFarmId: ${plan.id}
+  backupConfig:
+    type: azure-native:web:WebAppBackupConfiguration
+    properties:
+      resourceGroupName: ${rg.name}
+      name: ${app.name}
+      enabled: true
+      storageAccountUrl: "https://${storage.name}.blob.core.windows.net/${backupContainer.name}?${sasToken.accountSasToken}"
+      backupSchedule:
+        frequencyInterval: 7
+        frequencyUnit: "Day"
+        keepAtLeastOneBackup: true
+        retentionPeriodInDays: 30
+outputs:
+  backupConfigId: ${backupConfig.id}

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -157,6 +157,11 @@ type AzureAPIResource struct {
 	// Contains metadata for how to call the Listing operation for this resource
 	// when there is no metadata, the resource is not listable.
 	ListMetadata *AzureAPIListMetadata `json:"listMetadata,omitempty"`
+	// By default, after a successful Create the provider replaces the constructed resource ID with
+	// whatever "id" field is present in the PUT response body, on the assumption that it's the
+	// canonical ID. IgnoreResponseID overrides this for resources where that assumption is false,
+	// e.g. singleton config sub-resources whose PUT response returns their parent's id.
+	IgnoreResponseID bool `json:"ignoreResponseId,omitempty"`
 }
 
 type ResourceLookupFunc func(resourceType string) (AzureAPIResource, bool, error)
@@ -749,6 +754,41 @@ func AutoLocationDisabled(path string) bool {
 		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.documentdb/databaseaccounts/{accountname}/sqldatabases/{databasename}/containers/{containername}",
 		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.documentdb/databaseaccounts/{accountname}/tables/{tablename}":
 		// Child resources of Cosmos DB accounts.
+		return true
+	default:
+		return false
+	}
+}
+
+// IgnoreResponseID returns true if the "id" field of the PUT response for a given resource path
+// must not be trusted as the resource's canonical ID.
+//
+// These are all singleton "config" sub-resources nested under a Microsoft.Web site (optionally a
+// deployment slot). They aren't standalone ARM resources with their own identity: Azure's PUT
+// response for them returns the *parent* site's (or slot's) id, not a path ending in their own
+// "/config/<name>" segment. Blindly adopting that id corrupts the state's resource ID, breaking the
+// subsequent read and causing spurious creates on every refresh. See issue #4408.
+func IgnoreResponseID(path string) bool {
+	switch strings.ToLower(path) {
+	case "/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/appsettings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/appsettings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/authsettings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/authsettings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/authsettingsv2",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/authsettingsv2",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/azurestorageaccounts",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/azurestorageaccounts",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/backup",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/backup",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/connectionstrings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/connectionstrings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/logs",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/logs",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/metadata",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/metadata",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/pushsettings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/slots/{slot}/config/pushsettings",
+		"/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.web/sites/{name}/config/slotconfignames":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

- Azure's PUT response for singleton "config" sub-resources under `Microsoft.Web` sites (`WebAppBackupConfiguration`, `WebAppApplicationSettings`, `WebAppAuthSettings(V2)`, `WebAppAzureStorageAccounts`, `WebAppConnectionStrings`, `WebAppDiagnosticLogsConfiguration`, `WebAppMetadata`, `WebAppSitePushSettings`, `WebAppSlotConfigurationNames`, and their `Slot` variants) returns the **parent site's** `id`, not the sub-resource's own id.
- The provider was blindly adopting that `id` as canonical after `Create` (`provider.go`'s `defaultCreate`), corrupting the stored resource id. Every subsequent refresh/read then hit the wrong URL and failed, showing a spurious `create` forever (fixes #4408).
- Adds `resources.IgnoreResponseID(path)` — same hand-written pattern as the existing `AutoLocationDisabled` — to opt these resources out of the id-override, wired through codegen (`schema.go`) and `defaultCreate`.

## Test plan

- [x] Added `TestDefaultCreateIgnoreResponseID` unit test covering both branches of the new guard.
- [x] Added `TestWebAppBackupConfiguration` e2e test (new `test-programs/webapp-backup-configuration`) that deploys a real WebApp + WebAppBackupConfiguration, asserts no "Failed to read resource after Create" warning, and that refresh/a repeat `up` are no-ops.
- [x] Ran the new e2e test live against Azure: confirmed the bug reproduces without the fix and is resolved with it; test resources were destroyed afterward.
- [x] `go test ./pkg/provider/... ./pkg/resources/... ./pkg/gen/... ./pkg/azure/...` (unit tags) pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)