### PR TITLE
Fix #1749: KeyVault Vault sku.name no longer shows a spurious diff after import

### DIFF
--- a/provider/pkg/gen/properties_test.go
+++ b/provider/pkg/gen/properties_test.go
@@ -128,6 +128,12 @@ func TestCaseInsensitiveDiff(t *testing.T) {
 	searchService := moduleGenerator{moduleName: "Search", resourceName: "Service"}
 	assert.True(t, searchService.caseInsensitiveDiff("hostingMode"))
 	assert.False(t, searchService.caseInsensitiveDiff("someOtherProperty"))
+
+	vault := moduleGenerator{moduleName: "KeyVault", resourceName: "Vault"}
+	otherKeyVaultResource := moduleGenerator{moduleName: "KeyVault", resourceName: "ManagedHsm"}
+	assert.True(t, vault.caseInsensitiveDiff("name"))
+	assert.False(t, vault.caseInsensitiveDiff("someOtherProperty"))
+	assert.False(t, otherKeyVaultResource.caseInsensitiveDiff("name"))
 }
 
 func TestNoDefault(t *testing.T) {

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -142,6 +142,13 @@ var caseInsensitiveDiffMap = map[openapi.ModuleName]map[string]codegen.StringSet
 		// first deploy or import. See https://github.com/pulumi/pulumi-azure-native/issues/1684.
 		"Service": codegen.NewStringSet("hostingMode"),
 	},
+	"KeyVault": {
+		// sku.name resolves to "standard"/"premium" in the spec/SDK enum, but vaults created via
+		// ARM/Bicep/Portal with non-canonical casing (e.g. "Standard") have the KeyVault RP echo
+		// that casing back verbatim on GET, producing a spurious diff on import. See
+		// https://github.com/pulumi/pulumi-azure-native/issues/1749.
+		"Vault": codegen.NewStringSet("name"),
+	},
 }
 
 // noDefaultMap is a map of Module Name -> Resource Name -> properties whose spec-declared `default`

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -720,6 +720,79 @@ func TestManagedClusterBackendPoolTypeDiffingIsCaseInsensitive(t *testing.T) {
 	})
 }
 
+// TestVaultSkuNameDiffingIsCaseInsensitive is a regression test for
+// https://github.com/pulumi/pulumi-azure-native/issues/1749: the spec/SDK enum for sku.name resolves to
+// "standard"/"premium", but a Vault created via ARM/Bicep/Portal with non-canonical casing (e.g.
+// "Standard") has the KeyVault RP echo that casing back verbatim on GET, producing a spurious diff on
+// import. Only sku.name is marked CaseInsensitive; a sibling property must still diff normally, proving
+// the exception is scoped to that one property.
+func TestVaultSkuNameDiffingIsCaseInsensitive(t *testing.T) {
+	const skuRef = "#/types/azure-native:keyvault:Sku"
+
+	res := resources.AzureAPIResource{
+		PutParameters: []resources.AzureAPIParameter{
+			{
+				Location: "body",
+				Name:     "bodyProperties",
+				Body: &resources.AzureAPIType{
+					Properties: map[string]resources.AzureAPIProperty{
+						"sku": {Ref: skuRef},
+					},
+				},
+			},
+		},
+	}
+
+	lookupType := func(ref string) (*resources.AzureAPIType, bool, error) {
+		switch ref {
+		case skuRef:
+			return &resources.AzureAPIType{
+				Properties: map[string]resources.AzureAPIProperty{
+					"name":   {Type: "string", CaseInsensitive: true},
+					"family": {Type: "string"},
+				},
+			}, true, nil
+		}
+		return nil, false, nil
+	}
+
+	skuInputs := func(name, family string) resource.PropertyMap {
+		return resource.PropertyMap{
+			"sku": {V: resource.PropertyMap{
+				"name":   {V: name},
+				"family": {V: family},
+			}},
+		}
+	}
+
+	t.Run("casing-only difference is not a diff", func(t *testing.T) {
+		oldInputs := skuInputs("Standard", "A")
+		newInputs := skuInputs("standard", "A")
+		actual := diff(lookupType, res, oldInputs, newInputs)
+		assert.Nil(t, actual)
+	})
+
+	t.Run("a genuine value change still diffs", func(t *testing.T) {
+		oldInputs := skuInputs("standard", "A")
+		newInputs := skuInputs("premium", "A")
+		actual := diff(lookupType, res, oldInputs, newInputs)
+		expected := map[string]*rpc.PropertyDiff{
+			"sku.name": {Kind: rpc.PropertyDiff_UPDATE},
+		}
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("casing difference on a sibling property without the exception still diffs", func(t *testing.T) {
+		oldInputs := skuInputs("standard", "A")
+		newInputs := skuInputs("standard", "a")
+		actual := diff(lookupType, res, oldInputs, newInputs)
+		expected := map[string]*rpc.PropertyDiff{
+			"sku.family": {Kind: rpc.PropertyDiff_UPDATE},
+		}
+		assert.Equal(t, expected, actual)
+	})
+}
+
 var emptyTypes resources.TypeLookupFunc = func(t string) (*resources.AzureAPIType, bool, error) {
 	return nil, false, nil
 }


### PR DESCRIPTION
## Summary

- Vaults created via ARM/Bicep/Portal with non-canonical casing for `sku.name` (e.g. `"Standard"` instead of the spec/SDK enum's `"standard"`) have the KeyVault RP echo that casing back verbatim on GET. After `pulumi import`, this produced a permanent spurious `~ sku.name: "Standard" => "standard"` diff on every subsequent `pulumi preview`, even with no actual change.
- `sku.name` is now diffed case-insensitively via `caseInsensitiveDiffMap`, the same mechanism already used for AKS's `ManagedCluster.networkProfile.loadBalancerProfile.backendPoolType` (#4772) and Search's `Service.hostingMode` (#1684).

## Test plan

- [x] Added `TestVaultSkuNameDiffingIsCaseInsensitive` in `provider/pkg/provider/diff_test.go`, covering: casing-only difference is not a diff, a genuine value change still diffs, and a sibling property (`sku.family`) without the exception still diffs normally.
- [x] Extended `TestCaseInsensitiveDiff` in `provider/pkg/gen/properties_test.go` to cover the new `KeyVault.Vault` map entry, and that it doesn't leak to `KeyVault.ManagedHsm`.
- [x] `go test -tags=unit ./pkg/gen/... ./pkg/provider/...` passes (pre-existing unrelated failure: `TestParameterizePackageAdd` needs `yarn`, not installed in this environment).
- [x] Manually verified end-to-end: deployed a KeyVault via a raw ARM template with `sku.name: "Standard"`, imported it into a Pulumi stack, and confirmed `pulumi preview --diff` showed the spurious diff against the current released provider (v3.26.0) and showed no diff after rebuilding the provider with this fix.

Fixes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)