### PR TITLE
Fix #4623: remove dead codegen workaround dropping GovernanceRule/Application conditionSets

### DIFF
--- a/provider/pkg/gen/properties.go
+++ b/provider/pkg/gen/properties.go
@@ -116,12 +116,6 @@ func (m *moduleGenerator) genProperties(resolvedSchema *openapi.Schema, variants
 			continue
 		}
 
-		// TODO: Workaround for https://github.com/pulumi/pulumi/issues/12629 - remove once merged
-		if (name == "conditionSets" && property.Items.Schema.Ref.String() == "#/definitions/GovernanceRuleConditionSets") ||
-			(name == "conditionSets" && property.Items.Schema.Ref.String() == "#/definitions/ApplicationConditionSets") {
-			continue
-		}
-
 		// Workaround for https://github.com/Azure/azure-rest-api-specs/issues/9432
 		if m.moduleName == "KeyVault" && m.resourceName == "Vault" {
 			if name == "vaultUri" || name == "provisioningState" {


### PR DESCRIPTION
## Summary
- `azure-native.security.GovernanceRule` (and `SecurityConnectorApplication`) input `conditionSets` is generated and settable in all SDKs today — verified in Node.js (`any[]`), Python (`Sequence[Any]`), Go (`[]interface{}`), and .NET (`InputList<object>`), each compiling cleanly.
- The codegen workaround for pulumi/pulumi#12629 dropped `conditionSets` only when its `$ref` matched the old `GovernanceRuleConditionSets`/`ApplicationConditionSets` definitions. Azure since changed the spec so `conditionSets` is a plain untyped array (`items: {}`), so that `$ref` no longer exists and the workaround was dead code — confirmed by diffing schema output for the `security` namespace with and without it (byte-identical).
- This PR just deletes the now redundant workaround. 

Closes #4623

## Test plan
- [x] `go build ./...` in `provider/`
- [x] Regenerated the `security` namespace schema with/without the workaround — identical output
- [x] Generated Node.js/Python/Go/.NET SDKs from that schema and confirmed `conditionSets` types compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)