### PR TITLE
Improve error message for #2816 and related issues: avoid misleading "resource created but read failed" on failed async operations

### DIFF
--- a/provider/pkg/provider/crud/crud.go
+++ b/provider/pkg/provider/crud/crud.go
@@ -279,7 +279,17 @@ func (r *resourceCrudClient) HandleErrorWithCheckpoint(ctx context.Context, err 
 	// Try reading its state by ID and return a partial error if succeeded.
 	checkpoint, getErr := r.currentResourceStateCheckpoint(ctx, id, inputs)
 	if getErr != nil {
-		// If reading the state failed, combine the errors but still return the partial state.
+		if azure.IsNotFound(getErr) {
+			// The resource is confirmed to not exist (e.g. a create/update's long-running
+			// operation ultimately failed after an initial 202 Accepted response, so the
+			// operation never actually completed). There is no partial state to preserve,
+			// so return the original failure directly instead of a confusing compound
+			// error like "resource created but read failed 404 ...: <original error>".
+			return azure.AzureError(err)
+		}
+		// If reading the state failed for some other, possibly transient, reason, we can't
+		// tell whether the resource exists or not. Combine the errors but still return a
+		// partial error so a subsequent operation can attempt to reconcile the state.
 		err = azure.AzureError(errors.Wrapf(err, "resource created but read failed %s", getErr))
 	}
 	return partialError(id, err, checkpoint, properties)

--- a/provider/pkg/provider/crud/crud_test.go
+++ b/provider/pkg/provider/crud/crud_test.go
@@ -2,11 +2,13 @@ package crud
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/resources"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -440,4 +442,58 @@ func TestContainsNilValues(t *testing.T) {
 			},
 		}))
 	})
+}
+
+// TestHandleErrorWithCheckpoint_NotFound is a regression test for issue #2816 and related issues
+// (#867, #1126, #1138, #1681, #2633, #2916): when a create/update's long-running operation
+// ultimately fails after an initial 202 Accepted response, the resource never actually came into
+// existence. The subsequent checkpoint read confirms this with a 404. In that case, the original
+// creation/update error should be returned directly instead of being wrapped into a confusing
+// compound "resource created but read failed 404 ...: <original error>" message.
+func TestHandleErrorWithCheckpoint_NotFound(t *testing.T) {
+	originalErr := errors.New(`Code="BadRequest" Message="The provided principal ID was not found in the AAD tenant(s)"`)
+
+	client := &azure.MockAzureClient{
+		GetResponseErr: &azure.PulumiAzcoreResponseError{
+			StatusCode: http.StatusNotFound,
+			ErrorCode:  "NotFound",
+			Message:    `Unable to find a SQL Role Assignment with ID [...]`,
+		},
+	}
+	res := &resources.AzureAPIResource{APIVersion: "2023-04-15"}
+	crudClient := NewResourceCrudClient(client, nil, nil, "123", res)
+
+	err := crudClient.HandleErrorWithCheckpoint(context.Background(), originalErr,
+		"/subscriptions/123/resourceGroups/rg/providers/Microsoft.DocumentDB/databaseAccounts/acct/sqlRoleAssignments/abc",
+		resource.PropertyMap{}, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, originalErr.Error(), err.Error())
+	assert.NotContains(t, err.Error(), "read failed")
+}
+
+// TestHandleErrorWithCheckpoint_OtherReadError verifies the pre-existing behavior is preserved
+// when the checkpoint read fails for a reason other than a confirmed 404: since we can't tell
+// whether the resource exists, we still combine both errors into a partial error so a subsequent
+// operation can attempt to reconcile the state.
+func TestHandleErrorWithCheckpoint_OtherReadError(t *testing.T) {
+	originalErr := errors.New("original creation error")
+
+	client := &azure.MockAzureClient{
+		GetResponseErr: &azure.PulumiAzcoreResponseError{
+			StatusCode: http.StatusTooManyRequests,
+			ErrorCode:  "TooManyRequests",
+			Message:    "throttled",
+		},
+	}
+	res := &resources.AzureAPIResource{APIVersion: "2023-04-15"}
+	crudClient := NewResourceCrudClient(client, nil, nil, "123", res)
+
+	err := crudClient.HandleErrorWithCheckpoint(context.Background(), originalErr,
+		"/subscriptions/123/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa",
+		resource.PropertyMap{}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read failed")
+	assert.Contains(t, err.Error(), "original creation error")
 }


### PR DESCRIPTION
## Summary

When a create/update's PUT/PATCH request returns `202 Accepted` and the subsequent long-running operation ultimately fails (e.g. Azure's LRO body reports `{"status":"Failed", ...}`), the provider still treated the resource as created and attempted to read it back to build a checkpoint. Since the resource never actually came into existence, that read predictably 404s, and the two errors were combined into a misleading compound message:

```
resource created but read failed 404 ...: <original creation error>
```

This confuses users into thinking something was partially created when nothing was.

`HandleErrorWithCheckpoint` now checks whether the checkpoint read failed with a confirmed 404 (via the existing `azure.IsNotFound` helper). If so, it returns the original creation/update error directly instead of wrapping it in the confusing compound message. When the checkpoint read fails for some other, possibly transient, reason (where we genuinely can't tell if the resource exists), the existing conservative behavior — combine both errors into a partial error so a later operation can reconcile state — is unchanged.

## Affected issues

This exact error pattern was independently reported across several unrelated resource types, all sharing this same root cause. Leaving these open for now, since the underlying Azure-side eventual-consistency/LRO-failure behavior that *triggers* this code path is unaffected by this fix — only the resulting error message and provider-side bookkeeping are improved. Would like affected users to confirm the clearer message helps before closing:

- #2816 - Cosmos `SqlResourceSqlRoleAssignment` (AAD replication lag on a fresh `UserAssignedIdentity`)
- #2633 - Kusto `DatabasePrincipalAssignment`
- #2916 - PostgreSQL flexible server database
- #1681 - Event Grid subscription on an IoT Hub system topic
- #1126 - Azure AD B2C Tenant
- #1138 - Storage Account with a `network` property
- #867 - MySQL `PrivateEndpointConnection`

## Test plan

- [x] Added `TestHandleErrorWithCheckpoint_NotFound`: confirms a confirmed-404 checkpoint read now returns the plain original error instead of the compound message.
- [x] Added `TestHandleErrorWithCheckpoint_OtherReadError`: confirms the existing conservative behavior (combine both errors into a partial error) is preserved when the checkpoint read fails for a non-404 reason.
- [x] `go test ./pkg/provider/crud/... ./pkg/azure/...` passes.
- [x] `make test_provider PROVIDER_TEST_TAGS=unit` passes (one pre-existing, unrelated failure in `TestParameterizePackageAdd` due to `yarn` not being installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)