### PR TITLE
Update Communication default API version to 2026-03-18

### DIFF
--- a/reports/curationViolations.json
+++ b/reports/curationViolations.json
@@ -120,10 +120,6 @@
     "Detail": "expected no additions but found some"
   },
   {
-    "ModuleName": "Communication",
-    "Detail": "expected no additions but found some"
-  },
-  {
     "ModuleName": "ComputeBulkActions",
     "Detail": "expected tracking stable but found preview"
   },

--- a/reports/inactiveDefaultVersions.json
+++ b/reports/inactiveDefaultVersions.json
@@ -11,6 +11,9 @@
   "Cloudngfw": [
     "2025-05-23"
   ],
+  "Communication": [
+    "2026-03-18"
+  ],
   "ContainerStorage": [
     "2023-07-01-preview"
   ],

--- a/reports/pending.json
+++ b/reports/pending.json
@@ -260,13 +260,7 @@
     "2026-07-01"
   ],
   "Commerce": [],
-  "Communication": [
-    "2024-09-01-preview",
-    "2025-05-01",
-    "2025-05-01-preview",
-    "2025-09-01",
-    "2026-03-18"
-  ],
+  "Communication": [],
   "Community": [],
   "Compute": [
     "2024-03-03",

--- a/sdk/dotnet/Communication/CommunicationService.cs
+++ b/sdk/dotnet/Communication/CommunicationService.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// A class representing a CommunicationService resource.
     /// 
-    /// Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+    /// Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
     /// 
-    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// </summary>
     [AzureNativeResourceType("azure-native:communication:CommunicationService")]
     public partial class CommunicationService : global::Pulumi.CustomResource
@@ -32,13 +32,19 @@ namespace Pulumi.AzureNative.Communication
         public Output<string> DataLocation { get; private set; } = null!;
 
         /// <summary>
+        /// Disable local authentication for the CommunicationService.
+        /// </summary>
+        [Output("disableLocalAuth")]
+        public Output<bool?> DisableLocalAuth { get; private set; } = null!;
+
+        /// <summary>
         /// FQDN of the CommunicationService instance.
         /// </summary>
         [Output("hostName")]
         public Output<string> HostName { get; private set; } = null!;
 
         /// <summary>
-        /// Managed service identity (system assigned and/or user assigned identities)
+        /// The managed service identities assigned to this resource.
         /// </summary>
         [Output("identity")]
         public Output<Outputs.ManagedServiceIdentityResponse?> Identity { get; private set; } = null!;
@@ -78,6 +84,12 @@ namespace Pulumi.AzureNative.Communication
         /// </summary>
         [Output("provisioningState")]
         public Output<string> ProvisioningState { get; private set; } = null!;
+
+        /// <summary>
+        /// Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+        /// </summary>
+        [Output("publicNetworkAccess")]
+        public Output<string?> PublicNetworkAccess { get; private set; } = null!;
 
         /// <summary>
         /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
@@ -178,7 +190,13 @@ namespace Pulumi.AzureNative.Communication
         public Input<string> DataLocation { get; set; } = null!;
 
         /// <summary>
-        /// Managed service identity (system assigned and/or user assigned identities)
+        /// Disable local authentication for the CommunicationService.
+        /// </summary>
+        [Input("disableLocalAuth")]
+        public Input<bool>? DisableLocalAuth { get; set; }
+
+        /// <summary>
+        /// The managed service identities assigned to this resource.
         /// </summary>
         [Input("identity")]
         public Input<Inputs.ManagedServiceIdentityArgs>? Identity { get; set; }
@@ -200,6 +218,12 @@ namespace Pulumi.AzureNative.Communication
         /// </summary>
         [Input("location")]
         public Input<string>? Location { get; set; }
+
+        /// <summary>
+        /// Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+        /// </summary>
+        [Input("publicNetworkAccess")]
+        public InputUnion<string, Pulumi.AzureNative.Communication.PublicNetworkAccess>? PublicNetworkAccess { get; set; }
 
         /// <summary>
         /// The name of the resource group. The name is case insensitive.

--- a/sdk/dotnet/Communication/Domain.cs
+++ b/sdk/dotnet/Communication/Domain.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// A class representing a Domains resource.
     /// 
-    /// Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+    /// Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
     /// 
-    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// 
     /// Note: If `domainManagement` is set to `AzureManaged`, then `domainName` is required.
     /// </summary>
@@ -97,13 +97,13 @@ namespace Pulumi.AzureNative.Communication
         /// List of DnsRecord
         /// </summary>
         [Output("verificationRecords")]
-        public Output<Outputs.DomainPropertiesResponseVerificationRecords> VerificationRecords { get; private set; } = null!;
+        public Output<Outputs.DomainPropertiesVerificationRecordsResponse> VerificationRecords { get; private set; } = null!;
 
         /// <summary>
         /// List of VerificationStatusRecord
         /// </summary>
         [Output("verificationStates")]
-        public Output<Outputs.DomainPropertiesResponseVerificationStates> VerificationStates { get; private set; } = null!;
+        public Output<Outputs.DomainPropertiesVerificationStatesResponse> VerificationStates { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Communication/EmailService.cs
+++ b/sdk/dotnet/Communication/EmailService.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// A class representing an EmailService resource.
     /// 
-    /// Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+    /// Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
     /// 
-    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// </summary>
     [AzureNativeResourceType("azure-native:communication:EmailService")]
     public partial class EmailService : global::Pulumi.CustomResource

--- a/sdk/dotnet/Communication/Enums.cs
+++ b/sdk/dotnet/Communication/Enums.cs
@@ -20,8 +20,17 @@ namespace Pulumi.AzureNative.Communication
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// AzureManaged
+        /// </summary>
         public static DomainManagement AzureManaged { get; } = new DomainManagement("AzureManaged");
+        /// <summary>
+        /// CustomerManaged
+        /// </summary>
         public static DomainManagement CustomerManaged { get; } = new DomainManagement("CustomerManaged");
+        /// <summary>
+        /// CustomerManagedInExchangeOnline
+        /// </summary>
         public static DomainManagement CustomerManagedInExchangeOnline { get; } = new DomainManagement("CustomerManagedInExchangeOnline");
 
         public static bool operator ==(DomainManagement left, DomainManagement right) => left.Equals(right);
@@ -73,6 +82,47 @@ namespace Pulumi.AzureNative.Communication
     }
 
     /// <summary>
+    /// Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+    /// </summary>
+    [EnumType]
+    public readonly struct PublicNetworkAccess : IEquatable<PublicNetworkAccess>
+    {
+        private readonly string _value;
+
+        private PublicNetworkAccess(string value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Allows public network access to the resource
+        /// </summary>
+        public static PublicNetworkAccess Enabled { get; } = new PublicNetworkAccess("Enabled");
+        /// <summary>
+        /// Disallows public network access to the resource
+        /// </summary>
+        public static PublicNetworkAccess Disabled { get; } = new PublicNetworkAccess("Disabled");
+        /// <summary>
+        /// The network security perimeter configuration rules allow or disallow public network access to the resource. Requires an associated network security perimeter.
+        /// </summary>
+        public static PublicNetworkAccess SecuredByPerimeter { get; } = new PublicNetworkAccess("SecuredByPerimeter");
+
+        public static bool operator ==(PublicNetworkAccess left, PublicNetworkAccess right) => left.Equals(right);
+        public static bool operator !=(PublicNetworkAccess left, PublicNetworkAccess right) => !left.Equals(right);
+
+        public static explicit operator string(PublicNetworkAccess value) => value._value;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) => obj is PublicNetworkAccess other && Equals(other);
+        public bool Equals(PublicNetworkAccess other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+
+        public override string ToString() => _value;
+    }
+
+    /// <summary>
     /// Describes whether user engagement tracking is enabled or disabled.
     /// </summary>
     [EnumType]
@@ -85,7 +135,13 @@ namespace Pulumi.AzureNative.Communication
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// Disabled
+        /// </summary>
         public static UserEngagementTracking Disabled { get; } = new UserEngagementTracking("Disabled");
+        /// <summary>
+        /// Enabled
+        /// </summary>
         public static UserEngagementTracking Enabled { get; } = new UserEngagementTracking("Enabled");
 
         public static bool operator ==(UserEngagementTracking left, UserEngagementTracking right) => left.Equals(right);

--- a/sdk/dotnet/Communication/GetCommunicationService.cs
+++ b/sdk/dotnet/Communication/GetCommunicationService.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the CommunicationService and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetCommunicationServiceResult> InvokeAsync(GetCommunicationServiceArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetCommunicationServiceResult>("azure-native:communication:getCommunicationService", args ?? new GetCommunicationServiceArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the CommunicationService and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetCommunicationServiceResult> Invoke(GetCommunicationServiceInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetCommunicationServiceResult>("azure-native:communication:getCommunicationService", args ?? new GetCommunicationServiceInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the CommunicationService and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetCommunicationServiceResult> Invoke(GetCommunicationServiceInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetCommunicationServiceResult>("azure-native:communication:getCommunicationService", args ?? new GetCommunicationServiceInvokeArgs(), options.WithDefaults());
@@ -96,6 +96,10 @@ namespace Pulumi.AzureNative.Communication
         /// </summary>
         public readonly string DataLocation;
         /// <summary>
+        /// Disable local authentication for the CommunicationService.
+        /// </summary>
+        public readonly bool? DisableLocalAuth;
+        /// <summary>
         /// FQDN of the CommunicationService instance.
         /// </summary>
         public readonly string HostName;
@@ -104,7 +108,7 @@ namespace Pulumi.AzureNative.Communication
         /// </summary>
         public readonly string Id;
         /// <summary>
-        /// Managed service identity (system assigned and/or user assigned identities)
+        /// The managed service identities assigned to this resource.
         /// </summary>
         public readonly Outputs.ManagedServiceIdentityResponse? Identity;
         /// <summary>
@@ -132,6 +136,10 @@ namespace Pulumi.AzureNative.Communication
         /// </summary>
         public readonly string ProvisioningState;
         /// <summary>
+        /// Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+        /// </summary>
+        public readonly string? PublicNetworkAccess;
+        /// <summary>
         /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
         /// </summary>
         public readonly Outputs.SystemDataResponse SystemData;
@@ -154,6 +162,8 @@ namespace Pulumi.AzureNative.Communication
 
             string dataLocation,
 
+            bool? disableLocalAuth,
+
             string hostName,
 
             string id,
@@ -172,6 +182,8 @@ namespace Pulumi.AzureNative.Communication
 
             string provisioningState,
 
+            string? publicNetworkAccess,
+
             Outputs.SystemDataResponse systemData,
 
             ImmutableDictionary<string, string>? tags,
@@ -182,6 +194,7 @@ namespace Pulumi.AzureNative.Communication
         {
             AzureApiVersion = azureApiVersion;
             DataLocation = dataLocation;
+            DisableLocalAuth = disableLocalAuth;
             HostName = hostName;
             Id = id;
             Identity = identity;
@@ -191,6 +204,7 @@ namespace Pulumi.AzureNative.Communication
             Name = name;
             NotificationHubId = notificationHubId;
             ProvisioningState = provisioningState;
+            PublicNetworkAccess = publicNetworkAccess;
             SystemData = systemData;
             Tags = tags;
             Type = type;

--- a/sdk/dotnet/Communication/GetDomain.cs
+++ b/sdk/dotnet/Communication/GetDomain.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the Domains resource and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetDomainResult> InvokeAsync(GetDomainArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetDomainResult>("azure-native:communication:getDomain", args ?? new GetDomainArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the Domains resource and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetDomainResult> Invoke(GetDomainInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetDomainResult>("azure-native:communication:getDomain", args ?? new GetDomainInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the Domains resource and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetDomainResult> Invoke(GetDomainInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetDomainResult>("azure-native:communication:getDomain", args ?? new GetDomainInvokeArgs(), options.WithDefaults());
@@ -154,11 +154,11 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// List of DnsRecord
         /// </summary>
-        public readonly Outputs.DomainPropertiesResponseVerificationRecords VerificationRecords;
+        public readonly Outputs.DomainPropertiesVerificationRecordsResponse VerificationRecords;
         /// <summary>
         /// List of VerificationStatusRecord
         /// </summary>
-        public readonly Outputs.DomainPropertiesResponseVerificationStates VerificationStates;
+        public readonly Outputs.DomainPropertiesVerificationStatesResponse VerificationStates;
 
         [OutputConstructor]
         private GetDomainResult(
@@ -188,9 +188,9 @@ namespace Pulumi.AzureNative.Communication
 
             string? userEngagementTracking,
 
-            Outputs.DomainPropertiesResponseVerificationRecords verificationRecords,
+            Outputs.DomainPropertiesVerificationRecordsResponse verificationRecords,
 
-            Outputs.DomainPropertiesResponseVerificationStates verificationStates)
+            Outputs.DomainPropertiesVerificationStatesResponse verificationStates)
         {
             AzureApiVersion = azureApiVersion;
             DataLocation = dataLocation;

--- a/sdk/dotnet/Communication/GetEmailService.cs
+++ b/sdk/dotnet/Communication/GetEmailService.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the EmailService and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetEmailServiceResult> InvokeAsync(GetEmailServiceArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetEmailServiceResult>("azure-native:communication:getEmailService", args ?? new GetEmailServiceArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the EmailService and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetEmailServiceResult> Invoke(GetEmailServiceInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetEmailServiceResult>("azure-native:communication:getEmailService", args ?? new GetEmailServiceInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the EmailService and its properties.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetEmailServiceResult> Invoke(GetEmailServiceInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetEmailServiceResult>("azure-native:communication:getEmailService", args ?? new GetEmailServiceInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/Communication/GetSenderUsername.cs
+++ b/sdk/dotnet/Communication/GetSenderUsername.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a valid sender username for a domains resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetSenderUsernameResult> InvokeAsync(GetSenderUsernameArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetSenderUsernameResult>("azure-native:communication:getSenderUsername", args ?? new GetSenderUsernameArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a valid sender username for a domains resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSenderUsernameResult> Invoke(GetSenderUsernameInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetSenderUsernameResult>("azure-native:communication:getSenderUsername", args ?? new GetSenderUsernameInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a valid sender username for a domains resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSenderUsernameResult> Invoke(GetSenderUsernameInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetSenderUsernameResult>("azure-native:communication:getSenderUsername", args ?? new GetSenderUsernameInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/Communication/GetSmtpUsername.cs
+++ b/sdk/dotnet/Communication/GetSmtpUsername.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SmtpUsernameResource.
         /// 
-        /// Uses Azure REST API version 2024-09-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetSmtpUsernameResult> InvokeAsync(GetSmtpUsernameArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetSmtpUsernameResult>("azure-native:communication:getSmtpUsername", args ?? new GetSmtpUsernameArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SmtpUsernameResource.
         /// 
-        /// Uses Azure REST API version 2024-09-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSmtpUsernameResult> Invoke(GetSmtpUsernameInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetSmtpUsernameResult>("azure-native:communication:getSmtpUsername", args ?? new GetSmtpUsernameInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SmtpUsernameResource.
         /// 
-        /// Uses Azure REST API version 2024-09-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSmtpUsernameResult> Invoke(GetSmtpUsernameInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetSmtpUsernameResult>("azure-native:communication:getSmtpUsername", args ?? new GetSmtpUsernameInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/Communication/GetSuppressionList.cs
+++ b/sdk/dotnet/Communication/GetSuppressionList.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SuppressionList resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetSuppressionListResult> InvokeAsync(GetSuppressionListArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetSuppressionListResult>("azure-native:communication:getSuppressionList", args ?? new GetSuppressionListArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SuppressionList resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSuppressionListResult> Invoke(GetSuppressionListInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetSuppressionListResult>("azure-native:communication:getSuppressionList", args ?? new GetSuppressionListInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SuppressionList resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSuppressionListResult> Invoke(GetSuppressionListInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetSuppressionListResult>("azure-native:communication:getSuppressionList", args ?? new GetSuppressionListInvokeArgs(), options.WithDefaults());
@@ -132,7 +132,7 @@ namespace Pulumi.AzureNative.Communication
         /// </summary>
         public readonly string LastUpdatedTimeStamp;
         /// <summary>
-        /// The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        /// The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         /// </summary>
         public readonly string? ListName;
         /// <summary>

--- a/sdk/dotnet/Communication/GetSuppressionListAddress.cs
+++ b/sdk/dotnet/Communication/GetSuppressionListAddress.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SuppressionListAddress.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<GetSuppressionListAddressResult> InvokeAsync(GetSuppressionListAddressArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetSuppressionListAddressResult>("azure-native:communication:getSuppressionListAddress", args ?? new GetSuppressionListAddressArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SuppressionListAddress.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSuppressionListAddressResult> Invoke(GetSuppressionListAddressInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetSuppressionListAddressResult>("azure-native:communication:getSuppressionListAddress", args ?? new GetSuppressionListAddressInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get a SuppressionListAddress.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<GetSuppressionListAddressResult> Invoke(GetSuppressionListAddressInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetSuppressionListAddressResult>("azure-native:communication:getSuppressionListAddress", args ?? new GetSuppressionListAddressInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/Communication/ListCommunicationServiceKeys.cs
+++ b/sdk/dotnet/Communication/ListCommunicationServiceKeys.cs
@@ -14,9 +14,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the access keys of the CommunicationService resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Task<ListCommunicationServiceKeysResult> InvokeAsync(ListCommunicationServiceKeysArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<ListCommunicationServiceKeysResult>("azure-native:communication:listCommunicationServiceKeys", args ?? new ListCommunicationServiceKeysArgs(), options.WithDefaults());
@@ -24,9 +24,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the access keys of the CommunicationService resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<ListCommunicationServiceKeysResult> Invoke(ListCommunicationServiceKeysInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ListCommunicationServiceKeysResult>("azure-native:communication:listCommunicationServiceKeys", args ?? new ListCommunicationServiceKeysInvokeArgs(), options.WithDefaults());
@@ -34,9 +34,9 @@ namespace Pulumi.AzureNative.Communication
         /// <summary>
         /// Get the access keys of the CommunicationService resource.
         /// 
-        /// Uses Azure REST API version 2023-06-01-preview.
+        /// Uses Azure REST API version 2026-03-18.
         /// 
-        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
         /// </summary>
         public static Output<ListCommunicationServiceKeysResult> Invoke(ListCommunicationServiceKeysInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<ListCommunicationServiceKeysResult>("azure-native:communication:listCommunicationServiceKeys", args ?? new ListCommunicationServiceKeysInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/Communication/Outputs/DomainPropertiesVerificationRecordsResponse.cs
+++ b/sdk/dotnet/Communication/Outputs/DomainPropertiesVerificationRecordsResponse.cs
@@ -11,43 +11,43 @@ namespace Pulumi.AzureNative.Communication.Outputs
 {
 
     /// <summary>
-    /// List of VerificationStatusRecord
+    /// List of DnsRecord
     /// </summary>
     [OutputType]
-    public sealed class DomainPropertiesResponseVerificationStates
+    public sealed class DomainPropertiesVerificationRecordsResponse
     {
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.VerificationStatusRecordResponse? DKIM;
+        public readonly Outputs.DnsRecordResponse? DKIM;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.VerificationStatusRecordResponse? DKIM2;
+        public readonly Outputs.DnsRecordResponse? DKIM2;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.VerificationStatusRecordResponse? DMARC;
+        public readonly Outputs.DnsRecordResponse? DMARC;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.VerificationStatusRecordResponse? Domain;
+        public readonly Outputs.DnsRecordResponse? Domain;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.VerificationStatusRecordResponse? SPF;
+        public readonly Outputs.DnsRecordResponse? SPF;
 
         [OutputConstructor]
-        private DomainPropertiesResponseVerificationStates(
-            Outputs.VerificationStatusRecordResponse? dKIM,
+        private DomainPropertiesVerificationRecordsResponse(
+            Outputs.DnsRecordResponse? dKIM,
 
-            Outputs.VerificationStatusRecordResponse? dKIM2,
+            Outputs.DnsRecordResponse? dKIM2,
 
-            Outputs.VerificationStatusRecordResponse? dMARC,
+            Outputs.DnsRecordResponse? dMARC,
 
-            Outputs.VerificationStatusRecordResponse? domain,
+            Outputs.DnsRecordResponse? domain,
 
-            Outputs.VerificationStatusRecordResponse? sPF)
+            Outputs.DnsRecordResponse? sPF)
         {
             DKIM = dKIM;
             DKIM2 = dKIM2;

--- a/sdk/dotnet/Communication/Outputs/DomainPropertiesVerificationStatesResponse.cs
+++ b/sdk/dotnet/Communication/Outputs/DomainPropertiesVerificationStatesResponse.cs
@@ -11,43 +11,43 @@ namespace Pulumi.AzureNative.Communication.Outputs
 {
 
     /// <summary>
-    /// List of DnsRecord
+    /// List of VerificationStatusRecord
     /// </summary>
     [OutputType]
-    public sealed class DomainPropertiesResponseVerificationRecords
+    public sealed class DomainPropertiesVerificationStatesResponse
     {
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.DnsRecordResponse? DKIM;
+        public readonly Outputs.VerificationStatusRecordResponse? DKIM;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.DnsRecordResponse? DKIM2;
+        public readonly Outputs.VerificationStatusRecordResponse? DKIM2;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.DnsRecordResponse? DMARC;
+        public readonly Outputs.VerificationStatusRecordResponse? DMARC;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.DnsRecordResponse? Domain;
+        public readonly Outputs.VerificationStatusRecordResponse? Domain;
         /// <summary>
         /// A class that represents a VerificationStatus record.
         /// </summary>
-        public readonly Outputs.DnsRecordResponse? SPF;
+        public readonly Outputs.VerificationStatusRecordResponse? SPF;
 
         [OutputConstructor]
-        private DomainPropertiesResponseVerificationRecords(
-            Outputs.DnsRecordResponse? dKIM,
+        private DomainPropertiesVerificationStatesResponse(
+            Outputs.VerificationStatusRecordResponse? dKIM,
 
-            Outputs.DnsRecordResponse? dKIM2,
+            Outputs.VerificationStatusRecordResponse? dKIM2,
 
-            Outputs.DnsRecordResponse? dMARC,
+            Outputs.VerificationStatusRecordResponse? dMARC,
 
-            Outputs.DnsRecordResponse? domain,
+            Outputs.VerificationStatusRecordResponse? domain,
 
-            Outputs.DnsRecordResponse? sPF)
+            Outputs.VerificationStatusRecordResponse? sPF)
         {
             DKIM = dKIM;
             DKIM2 = dKIM2;

--- a/sdk/dotnet/Communication/SenderUsername.cs
+++ b/sdk/dotnet/Communication/SenderUsername.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// A class representing a SenderUsername resource.
     /// 
-    /// Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+    /// Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
     /// 
-    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// </summary>
     [AzureNativeResourceType("azure-native:communication:SenderUsername")]
     public partial class SenderUsername : global::Pulumi.CustomResource

--- a/sdk/dotnet/Communication/SmtpUsername.cs
+++ b/sdk/dotnet/Communication/SmtpUsername.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// The object describing the smtp username resource.
     /// 
-    /// Uses Azure REST API version 2024-09-01-preview.
+    /// Uses Azure REST API version 2026-03-18.
     /// 
-    /// Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// </summary>
     [AzureNativeResourceType("azure-native:communication:SmtpUsername")]
     public partial class SmtpUsername : global::Pulumi.CustomResource

--- a/sdk/dotnet/Communication/SuppressionList.cs
+++ b/sdk/dotnet/Communication/SuppressionList.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// A class representing a SuppressionList resource.
     /// 
-    /// Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+    /// Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
     /// 
-    /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// </summary>
     [AzureNativeResourceType("azure-native:communication:SuppressionList")]
     public partial class SuppressionList : global::Pulumi.CustomResource
@@ -44,7 +44,7 @@ namespace Pulumi.AzureNative.Communication
         public Output<string> LastUpdatedTimeStamp { get; private set; } = null!;
 
         /// <summary>
-        /// The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        /// The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         /// </summary>
         [Output("listName")]
         public Output<string?> ListName { get; private set; } = null!;
@@ -133,7 +133,7 @@ namespace Pulumi.AzureNative.Communication
         public Input<string> EmailServiceName { get; set; } = null!;
 
         /// <summary>
-        /// The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        /// The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         /// </summary>
         [Input("listName")]
         public Input<string>? ListName { get; set; }

--- a/sdk/dotnet/Communication/SuppressionListAddress.cs
+++ b/sdk/dotnet/Communication/SuppressionListAddress.cs
@@ -12,9 +12,9 @@ namespace Pulumi.AzureNative.Communication
     /// <summary>
     /// A object that represents a SuppressionList record.
     /// 
-    /// Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+    /// Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
     /// 
-    /// Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    /// Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
     /// </summary>
     [AzureNativeResourceType("azure-native:communication:SuppressionListAddress")]
     public partial class SuppressionListAddress : global::Pulumi.CustomResource

--- a/sdk/nodejs/communication/communicationService.ts
+++ b/sdk/nodejs/communication/communicationService.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * A class representing a CommunicationService resource.
  *
- * Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+ * Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export class CommunicationService extends pulumi.CustomResource {
     /**
@@ -50,11 +50,15 @@ export class CommunicationService extends pulumi.CustomResource {
      */
     declare public readonly dataLocation: pulumi.Output<string>;
     /**
+     * Disable local authentication for the CommunicationService.
+     */
+    declare public readonly disableLocalAuth: pulumi.Output<boolean | undefined>;
+    /**
      * FQDN of the CommunicationService instance.
      */
     declare public /*out*/ readonly hostName: pulumi.Output<string>;
     /**
-     * Managed service identity (system assigned and/or user assigned identities)
+     * The managed service identities assigned to this resource.
      */
     declare public readonly identity: pulumi.Output<outputs.communication.ManagedServiceIdentityResponse | undefined>;
     /**
@@ -81,6 +85,10 @@ export class CommunicationService extends pulumi.CustomResource {
      * Provisioning state of the resource.
      */
     declare public /*out*/ readonly provisioningState: pulumi.Output<string>;
+    /**
+     * Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+     */
+    declare public readonly publicNetworkAccess: pulumi.Output<string | undefined>;
     /**
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
@@ -117,9 +125,11 @@ export class CommunicationService extends pulumi.CustomResource {
             }
             resourceInputs["communicationServiceName"] = args?.communicationServiceName;
             resourceInputs["dataLocation"] = args?.dataLocation;
+            resourceInputs["disableLocalAuth"] = args?.disableLocalAuth;
             resourceInputs["identity"] = args?.identity;
             resourceInputs["linkedDomains"] = args?.linkedDomains;
             resourceInputs["location"] = args?.location;
+            resourceInputs["publicNetworkAccess"] = args?.publicNetworkAccess;
             resourceInputs["resourceGroupName"] = args?.resourceGroupName;
             resourceInputs["tags"] = args?.tags;
             resourceInputs["azureApiVersion"] = undefined /*out*/;
@@ -134,6 +144,7 @@ export class CommunicationService extends pulumi.CustomResource {
         } else {
             resourceInputs["azureApiVersion"] = undefined /*out*/;
             resourceInputs["dataLocation"] = undefined /*out*/;
+            resourceInputs["disableLocalAuth"] = undefined /*out*/;
             resourceInputs["hostName"] = undefined /*out*/;
             resourceInputs["identity"] = undefined /*out*/;
             resourceInputs["immutableResourceId"] = undefined /*out*/;
@@ -142,6 +153,7 @@ export class CommunicationService extends pulumi.CustomResource {
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["notificationHubId"] = undefined /*out*/;
             resourceInputs["provisioningState"] = undefined /*out*/;
+            resourceInputs["publicNetworkAccess"] = undefined /*out*/;
             resourceInputs["systemData"] = undefined /*out*/;
             resourceInputs["tags"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
@@ -167,7 +179,11 @@ export interface CommunicationServiceArgs {
      */
     dataLocation: pulumi.Input<string>;
     /**
-     * Managed service identity (system assigned and/or user assigned identities)
+     * Disable local authentication for the CommunicationService.
+     */
+    disableLocalAuth?: pulumi.Input<boolean | undefined>;
+    /**
+     * The managed service identities assigned to this resource.
      */
     identity?: pulumi.Input<inputs.communication.ManagedServiceIdentityArgs | undefined>;
     /**
@@ -178,6 +194,10 @@ export interface CommunicationServiceArgs {
      * The geo-location where the resource lives
      */
     location?: pulumi.Input<string | undefined>;
+    /**
+     * Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+     */
+    publicNetworkAccess?: pulumi.Input<string | enums.communication.PublicNetworkAccess | undefined>;
     /**
      * The name of the resource group. The name is case insensitive.
      */

--- a/sdk/nodejs/communication/domain.ts
+++ b/sdk/nodejs/communication/domain.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * A class representing a Domains resource.
  *
- * Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+ * Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  *
  * Note: If `domainManagement` is set to `AzureManaged`, then `domainName` is required.
  */
@@ -94,11 +94,11 @@ export class Domain extends pulumi.CustomResource {
     /**
      * List of DnsRecord
      */
-    declare public /*out*/ readonly verificationRecords: pulumi.Output<outputs.communication.DomainPropertiesResponseVerificationRecords>;
+    declare public /*out*/ readonly verificationRecords: pulumi.Output<outputs.communication.DomainPropertiesVerificationRecordsResponse>;
     /**
      * List of VerificationStatusRecord
      */
-    declare public /*out*/ readonly verificationStates: pulumi.Output<outputs.communication.DomainPropertiesResponseVerificationStates>;
+    declare public /*out*/ readonly verificationStates: pulumi.Output<outputs.communication.DomainPropertiesVerificationStatesResponse>;
 
     /**
      * Create a Domain resource with the given unique name, arguments, and options.

--- a/sdk/nodejs/communication/emailService.ts
+++ b/sdk/nodejs/communication/emailService.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * A class representing an EmailService resource.
  *
- * Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+ * Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export class EmailService extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/communication/getCommunicationService.ts
+++ b/sdk/nodejs/communication/getCommunicationService.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get the CommunicationService and its properties.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getCommunicationService(args: GetCommunicationServiceArgs, opts?: pulumi.InvokeOptions): Promise<GetCommunicationServiceResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -46,6 +46,10 @@ export interface GetCommunicationServiceResult {
      */
     readonly dataLocation: string;
     /**
+     * Disable local authentication for the CommunicationService.
+     */
+    readonly disableLocalAuth?: boolean;
+    /**
      * FQDN of the CommunicationService instance.
      */
     readonly hostName: string;
@@ -54,7 +58,7 @@ export interface GetCommunicationServiceResult {
      */
     readonly id: string;
     /**
-     * Managed service identity (system assigned and/or user assigned identities)
+     * The managed service identities assigned to this resource.
      */
     readonly identity?: outputs.communication.ManagedServiceIdentityResponse;
     /**
@@ -82,6 +86,10 @@ export interface GetCommunicationServiceResult {
      */
     readonly provisioningState: string;
     /**
+     * Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+     */
+    readonly publicNetworkAccess?: string;
+    /**
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
     readonly systemData: outputs.communication.SystemDataResponse;
@@ -101,9 +109,9 @@ export interface GetCommunicationServiceResult {
 /**
  * Get the CommunicationService and its properties.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getCommunicationServiceOutput(args: GetCommunicationServiceOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetCommunicationServiceResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/getDomain.ts
+++ b/sdk/nodejs/communication/getDomain.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get the Domains resource and its properties.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getDomain(args: GetDomainArgs, opts?: pulumi.InvokeOptions): Promise<GetDomainResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -97,18 +97,18 @@ export interface GetDomainResult {
     /**
      * List of DnsRecord
      */
-    readonly verificationRecords: outputs.communication.DomainPropertiesResponseVerificationRecords;
+    readonly verificationRecords: outputs.communication.DomainPropertiesVerificationRecordsResponse;
     /**
      * List of VerificationStatusRecord
      */
-    readonly verificationStates: outputs.communication.DomainPropertiesResponseVerificationStates;
+    readonly verificationStates: outputs.communication.DomainPropertiesVerificationStatesResponse;
 }
 /**
  * Get the Domains resource and its properties.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getDomainOutput(args: GetDomainOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetDomainResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/getEmailService.ts
+++ b/sdk/nodejs/communication/getEmailService.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get the EmailService and its properties.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getEmailService(args: GetEmailServiceArgs, opts?: pulumi.InvokeOptions): Promise<GetEmailServiceResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -77,9 +77,9 @@ export interface GetEmailServiceResult {
 /**
  * Get the EmailService and its properties.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getEmailServiceOutput(args: GetEmailServiceOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetEmailServiceResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/getSenderUsername.ts
+++ b/sdk/nodejs/communication/getSenderUsername.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get a valid sender username for a domains resource.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSenderUsername(args: GetSenderUsernameArgs, opts?: pulumi.InvokeOptions): Promise<GetSenderUsernameResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -87,9 +87,9 @@ export interface GetSenderUsernameResult {
 /**
  * Get a valid sender username for a domains resource.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSenderUsernameOutput(args: GetSenderUsernameOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetSenderUsernameResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/getSmtpUsername.ts
+++ b/sdk/nodejs/communication/getSmtpUsername.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get a SmtpUsernameResource.
  *
- * Uses Azure REST API version 2024-09-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSmtpUsername(args: GetSmtpUsernameArgs, opts?: pulumi.InvokeOptions): Promise<GetSmtpUsernameResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -78,9 +78,9 @@ export interface GetSmtpUsernameResult {
 /**
  * Get a SmtpUsernameResource.
  *
- * Uses Azure REST API version 2024-09-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSmtpUsernameOutput(args: GetSmtpUsernameOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetSmtpUsernameResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/getSuppressionList.ts
+++ b/sdk/nodejs/communication/getSuppressionList.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get a SuppressionList resource.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSuppressionList(args: GetSuppressionListArgs, opts?: pulumi.InvokeOptions): Promise<GetSuppressionListResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -68,7 +68,7 @@ export interface GetSuppressionListResult {
      */
     readonly lastUpdatedTimeStamp: string;
     /**
-     * The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+     * The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
      */
     readonly listName?: string;
     /**
@@ -87,9 +87,9 @@ export interface GetSuppressionListResult {
 /**
  * Get a SuppressionList resource.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSuppressionListOutput(args: GetSuppressionListOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetSuppressionListResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/getSuppressionListAddress.ts
+++ b/sdk/nodejs/communication/getSuppressionListAddress.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * Get a SuppressionListAddress.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSuppressionListAddress(args: GetSuppressionListAddressArgs, opts?: pulumi.InvokeOptions): Promise<GetSuppressionListAddressResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -100,9 +100,9 @@ export interface GetSuppressionListAddressResult {
 /**
  * Get a SuppressionListAddress.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function getSuppressionListAddressOutput(args: GetSuppressionListAddressOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetSuppressionListAddressResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/listCommunicationServiceKeys.ts
+++ b/sdk/nodejs/communication/listCommunicationServiceKeys.ts
@@ -7,9 +7,9 @@ import * as utilities from "../utilities";
 /**
  * Get the access keys of the CommunicationService resource.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function listCommunicationServiceKeys(args: ListCommunicationServiceKeysArgs, opts?: pulumi.InvokeOptions): Promise<ListCommunicationServiceKeysResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -54,9 +54,9 @@ export interface ListCommunicationServiceKeysResult {
 /**
  * Get the access keys of the CommunicationService resource.
  *
- * Uses Azure REST API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export function listCommunicationServiceKeysOutput(args: ListCommunicationServiceKeysOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<ListCommunicationServiceKeysResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/nodejs/communication/senderUsername.ts
+++ b/sdk/nodejs/communication/senderUsername.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * A class representing a SenderUsername resource.
  *
- * Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+ * Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
  *
- * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export class SenderUsername extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/communication/smtpUsername.ts
+++ b/sdk/nodejs/communication/smtpUsername.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * The object describing the smtp username resource.
  *
- * Uses Azure REST API version 2024-09-01-preview.
+ * Uses Azure REST API version 2026-03-18.
  *
- * Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export class SmtpUsername extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/communication/suppressionList.ts
+++ b/sdk/nodejs/communication/suppressionList.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * A class representing a SuppressionList resource.
  *
- * Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
  *
- * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export class SuppressionList extends pulumi.CustomResource {
     /**
@@ -58,7 +58,7 @@ export class SuppressionList extends pulumi.CustomResource {
      */
     declare public /*out*/ readonly lastUpdatedTimeStamp: pulumi.Output<string>;
     /**
-     * The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+     * The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
      */
     declare public readonly listName: pulumi.Output<string | undefined>;
     /**
@@ -136,7 +136,7 @@ export interface SuppressionListArgs {
      */
     emailServiceName: pulumi.Input<string>;
     /**
-     * The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+     * The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
      */
     listName?: pulumi.Input<string | undefined>;
     /**

--- a/sdk/nodejs/communication/suppressionListAddress.ts
+++ b/sdk/nodejs/communication/suppressionListAddress.ts
@@ -10,9 +10,9 @@ import * as utilities from "../utilities";
 /**
  * A object that represents a SuppressionList record.
  *
- * Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+ * Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
  *
- * Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+ * Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
  */
 export class SuppressionListAddress extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/types/enums/communication/index.ts
+++ b/sdk/nodejs/types/enums/communication/index.ts
@@ -3,8 +3,17 @@
 
 
 export const DomainManagement = {
+    /**
+     * AzureManaged
+     */
     AzureManaged: "AzureManaged",
+    /**
+     * CustomerManaged
+     */
     CustomerManaged: "CustomerManaged",
+    /**
+     * CustomerManagedInExchangeOnline
+     */
     CustomerManagedInExchangeOnline: "CustomerManagedInExchangeOnline",
 } as const;
 
@@ -25,8 +34,34 @@ export const ManagedServiceIdentityType = {
  */
 export type ManagedServiceIdentityType = (typeof ManagedServiceIdentityType)[keyof typeof ManagedServiceIdentityType];
 
-export const UserEngagementTracking = {
+export const PublicNetworkAccess = {
+    /**
+     * Allows public network access to the resource
+     */
+    Enabled: "Enabled",
+    /**
+     * Disallows public network access to the resource
+     */
     Disabled: "Disabled",
+    /**
+     * The network security perimeter configuration rules allow or disallow public network access to the resource. Requires an associated network security perimeter.
+     */
+    SecuredByPerimeter: "SecuredByPerimeter",
+} as const;
+
+/**
+ * Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+ */
+export type PublicNetworkAccess = (typeof PublicNetworkAccess)[keyof typeof PublicNetworkAccess];
+
+export const UserEngagementTracking = {
+    /**
+     * Disabled
+     */
+    Disabled: "Disabled",
+    /**
+     * Enabled
+     */
     Enabled: "Enabled",
 } as const;
 

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -62312,7 +62312,7 @@ export namespace communication {
     /**
      * List of DnsRecord
      */
-    export interface DomainPropertiesResponseVerificationRecords {
+    export interface DomainPropertiesVerificationRecordsResponse {
         /**
          * A class that represents a VerificationStatus record.
          */
@@ -62338,7 +62338,7 @@ export namespace communication {
     /**
      * List of VerificationStatusRecord
      */
-    export interface DomainPropertiesResponseVerificationStates {
+    export interface DomainPropertiesVerificationStatesResponse {
         /**
          * A class that represents a VerificationStatus record.
          */

--- a/sdk/python/pulumi_azure_native/communication/_enums.py
+++ b/sdk/python/pulumi_azure_native/communication/_enums.py
@@ -9,6 +9,7 @@ from enum import Enum
 __all__ = [
     'DomainManagement',
     'ManagedServiceIdentityType',
+    'PublicNetworkAccess',
     'UserEngagementTracking',
 ]
 
@@ -19,8 +20,17 @@ class DomainManagement(_builtins.str, Enum):
     Describes how a Domains resource is being managed.
     """
     AZURE_MANAGED = "AzureManaged"
+    """
+    AzureManaged
+    """
     CUSTOMER_MANAGED = "CustomerManaged"
+    """
+    CustomerManaged
+    """
     CUSTOMER_MANAGED_IN_EXCHANGE_ONLINE = "CustomerManagedInExchangeOnline"
+    """
+    CustomerManagedInExchangeOnline
+    """
 
 
 @pulumi.type_token("azure-native:communication:ManagedServiceIdentityType")
@@ -34,10 +44,35 @@ class ManagedServiceIdentityType(_builtins.str, Enum):
     SYSTEM_ASSIGNED_USER_ASSIGNED = "SystemAssigned,UserAssigned"
 
 
+@pulumi.type_token("azure-native:communication:PublicNetworkAccess")
+class PublicNetworkAccess(_builtins.str, Enum):
+    """
+    Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+    """
+    ENABLED = "Enabled"
+    """
+    Allows public network access to the resource
+    """
+    DISABLED = "Disabled"
+    """
+    Disallows public network access to the resource
+    """
+    SECURED_BY_PERIMETER = "SecuredByPerimeter"
+    """
+    The network security perimeter configuration rules allow or disallow public network access to the resource. Requires an associated network security perimeter.
+    """
+
+
 @pulumi.type_token("azure-native:communication:UserEngagementTracking")
 class UserEngagementTracking(_builtins.str, Enum):
     """
     Describes whether user engagement tracking is enabled or disabled.
     """
     DISABLED = "Disabled"
+    """
+    Disabled
+    """
     ENABLED = "Enabled"
+    """
+    Enabled
+    """

--- a/sdk/python/pulumi_azure_native/communication/communication_service.py
+++ b/sdk/python/pulumi_azure_native/communication/communication_service.py
@@ -25,9 +25,11 @@ class CommunicationServiceArgs:
                  data_location: pulumi.Input[_builtins.str],
                  resource_group_name: pulumi.Input[_builtins.str],
                  communication_service_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 disable_local_auth: pulumi.Input[Optional[_builtins.bool]] = None,
                  identity: pulumi.Input[Optional['ManagedServiceIdentityArgs']] = None,
                  linked_domains: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  location: pulumi.Input[Optional[_builtins.str]] = None,
+                 public_network_access: pulumi.Input[Optional[Union[_builtins.str, 'PublicNetworkAccess']]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a CommunicationService resource.
@@ -35,21 +37,27 @@ class CommunicationServiceArgs:
         :param pulumi.Input[_builtins.str] data_location: The location where the communication service stores its data at rest.
         :param pulumi.Input[_builtins.str] resource_group_name: The name of the resource group. The name is case insensitive.
         :param pulumi.Input[_builtins.str] communication_service_name: The name of the CommunicationService resource.
-        :param pulumi.Input['ManagedServiceIdentityArgs'] identity: Managed service identity (system assigned and/or user assigned identities)
+        :param pulumi.Input[_builtins.bool] disable_local_auth: Disable local authentication for the CommunicationService.
+        :param pulumi.Input['ManagedServiceIdentityArgs'] identity: The managed service identities assigned to this resource.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] linked_domains: List of email Domain resource Ids.
         :param pulumi.Input[_builtins.str] location: The geo-location where the resource lives
+        :param pulumi.Input[Union[_builtins.str, 'PublicNetworkAccess']] public_network_access: Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Resource tags.
         """
         pulumi.set(__self__, "data_location", data_location)
         pulumi.set(__self__, "resource_group_name", resource_group_name)
         if communication_service_name is not None:
             pulumi.set(__self__, "communication_service_name", communication_service_name)
+        if disable_local_auth is not None:
+            pulumi.set(__self__, "disable_local_auth", disable_local_auth)
         if identity is not None:
             pulumi.set(__self__, "identity", identity)
         if linked_domains is not None:
             pulumi.set(__self__, "linked_domains", linked_domains)
         if location is not None:
             pulumi.set(__self__, "location", location)
+        if public_network_access is not None:
+            pulumi.set(__self__, "public_network_access", public_network_access)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -90,10 +98,22 @@ class CommunicationServiceArgs:
         pulumi.set(self, "communication_service_name", value)
 
     @_builtins.property
+    @pulumi.getter(name="disableLocalAuth")
+    def disable_local_auth(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Disable local authentication for the CommunicationService.
+        """
+        return pulumi.get(self, "disable_local_auth")
+
+    @disable_local_auth.setter
+    def disable_local_auth(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "disable_local_auth", value)
+
+    @_builtins.property
     @pulumi.getter
     def identity(self) -> pulumi.Input[Optional['ManagedServiceIdentityArgs']]:
         """
-        Managed service identity (system assigned and/or user assigned identities)
+        The managed service identities assigned to this resource.
         """
         return pulumi.get(self, "identity")
 
@@ -126,6 +146,18 @@ class CommunicationServiceArgs:
         pulumi.set(self, "location", value)
 
     @_builtins.property
+    @pulumi.getter(name="publicNetworkAccess")
+    def public_network_access(self) -> pulumi.Input[Optional[Union[_builtins.str, 'PublicNetworkAccess']]]:
+        """
+        Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+        """
+        return pulumi.get(self, "public_network_access")
+
+    @public_network_access.setter
+    def public_network_access(self, value: pulumi.Input[Optional[Union[_builtins.str, 'PublicNetworkAccess']]]):
+        pulumi.set(self, "public_network_access", value)
+
+    @_builtins.property
     @pulumi.getter
     def tags(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]:
         """
@@ -146,26 +178,30 @@ class CommunicationService(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  communication_service_name: pulumi.Input[Optional[_builtins.str]] = None,
                  data_location: pulumi.Input[Optional[_builtins.str]] = None,
+                 disable_local_auth: pulumi.Input[Optional[_builtins.bool]] = None,
                  identity: pulumi.Input[Optional[Union['ManagedServiceIdentityArgs', 'ManagedServiceIdentityArgsDict']]] = None,
                  linked_domains: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  location: pulumi.Input[Optional[_builtins.str]] = None,
+                 public_network_access: pulumi.Input[Optional[Union[_builtins.str, 'PublicNetworkAccess']]] = None,
                  resource_group_name: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
         """
         A class representing a CommunicationService resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] communication_service_name: The name of the CommunicationService resource.
         :param pulumi.Input[_builtins.str] data_location: The location where the communication service stores its data at rest.
-        :param pulumi.Input[Union['ManagedServiceIdentityArgs', 'ManagedServiceIdentityArgsDict']] identity: Managed service identity (system assigned and/or user assigned identities)
+        :param pulumi.Input[_builtins.bool] disable_local_auth: Disable local authentication for the CommunicationService.
+        :param pulumi.Input[Union['ManagedServiceIdentityArgs', 'ManagedServiceIdentityArgsDict']] identity: The managed service identities assigned to this resource.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] linked_domains: List of email Domain resource Ids.
         :param pulumi.Input[_builtins.str] location: The geo-location where the resource lives
+        :param pulumi.Input[Union[_builtins.str, 'PublicNetworkAccess']] public_network_access: Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
         :param pulumi.Input[_builtins.str] resource_group_name: The name of the resource group. The name is case insensitive.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Resource tags.
         """
@@ -178,9 +214,9 @@ class CommunicationService(pulumi.CustomResource):
         """
         A class representing a CommunicationService resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param CommunicationServiceArgs args: The arguments to use to populate this resource's properties.
@@ -199,9 +235,11 @@ class CommunicationService(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  communication_service_name: pulumi.Input[Optional[_builtins.str]] = None,
                  data_location: pulumi.Input[Optional[_builtins.str]] = None,
+                 disable_local_auth: pulumi.Input[Optional[_builtins.bool]] = None,
                  identity: pulumi.Input[Optional[Union['ManagedServiceIdentityArgs', 'ManagedServiceIdentityArgsDict']]] = None,
                  linked_domains: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  location: pulumi.Input[Optional[_builtins.str]] = None,
+                 public_network_access: pulumi.Input[Optional[Union[_builtins.str, 'PublicNetworkAccess']]] = None,
                  resource_group_name: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
@@ -217,9 +255,11 @@ class CommunicationService(pulumi.CustomResource):
             if data_location is None and not opts.urn:
                 raise TypeError("Missing required property 'data_location'")
             __props__.__dict__["data_location"] = data_location
+            __props__.__dict__["disable_local_auth"] = disable_local_auth
             __props__.__dict__["identity"] = identity
             __props__.__dict__["linked_domains"] = linked_domains
             __props__.__dict__["location"] = location
+            __props__.__dict__["public_network_access"] = public_network_access
             if resource_group_name is None and not opts.urn:
                 raise TypeError("Missing required property 'resource_group_name'")
             __props__.__dict__["resource_group_name"] = resource_group_name
@@ -259,6 +299,7 @@ class CommunicationService(pulumi.CustomResource):
 
         __props__.__dict__["azure_api_version"] = None
         __props__.__dict__["data_location"] = None
+        __props__.__dict__["disable_local_auth"] = None
         __props__.__dict__["host_name"] = None
         __props__.__dict__["identity"] = None
         __props__.__dict__["immutable_resource_id"] = None
@@ -267,6 +308,7 @@ class CommunicationService(pulumi.CustomResource):
         __props__.__dict__["name"] = None
         __props__.__dict__["notification_hub_id"] = None
         __props__.__dict__["provisioning_state"] = None
+        __props__.__dict__["public_network_access"] = None
         __props__.__dict__["system_data"] = None
         __props__.__dict__["tags"] = None
         __props__.__dict__["type"] = None
@@ -290,6 +332,14 @@ class CommunicationService(pulumi.CustomResource):
         return pulumi.get(self, "data_location")
 
     @_builtins.property
+    @pulumi.getter(name="disableLocalAuth")
+    def disable_local_auth(self) -> pulumi.Output[Optional[_builtins.bool]]:
+        """
+        Disable local authentication for the CommunicationService.
+        """
+        return pulumi.get(self, "disable_local_auth")
+
+    @_builtins.property
     @pulumi.getter(name="hostName")
     def host_name(self) -> pulumi.Output[_builtins.str]:
         """
@@ -301,7 +351,7 @@ class CommunicationService(pulumi.CustomResource):
     @pulumi.getter
     def identity(self) -> pulumi.Output[Optional['outputs.ManagedServiceIdentityResponse']]:
         """
-        Managed service identity (system assigned and/or user assigned identities)
+        The managed service identities assigned to this resource.
         """
         return pulumi.get(self, "identity")
 
@@ -352,6 +402,14 @@ class CommunicationService(pulumi.CustomResource):
         Provisioning state of the resource.
         """
         return pulumi.get(self, "provisioning_state")
+
+    @_builtins.property
+    @pulumi.getter(name="publicNetworkAccess")
+    def public_network_access(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+        """
+        return pulumi.get(self, "public_network_access")
 
     @_builtins.property
     @pulumi.getter(name="systemData")

--- a/sdk/python/pulumi_azure_native/communication/domain.py
+++ b/sdk/python/pulumi_azure_native/communication/domain.py
@@ -153,9 +153,9 @@ class Domain(pulumi.CustomResource):
         """
         A class representing a Domains resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         Note: If `domainManagement` is set to `AzureManaged`, then `domainName` is required.
 
@@ -179,9 +179,9 @@ class Domain(pulumi.CustomResource):
         """
         A class representing a Domains resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         Note: If `domainManagement` is set to `AzureManaged`, then `domainName` is required.
 
@@ -378,7 +378,7 @@ class Domain(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="verificationRecords")
-    def verification_records(self) -> pulumi.Output['outputs.DomainPropertiesResponseVerificationRecords']:
+    def verification_records(self) -> pulumi.Output['outputs.DomainPropertiesVerificationRecordsResponse']:
         """
         List of DnsRecord
         """
@@ -386,7 +386,7 @@ class Domain(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="verificationStates")
-    def verification_states(self) -> pulumi.Output['outputs.DomainPropertiesResponseVerificationStates']:
+    def verification_states(self) -> pulumi.Output['outputs.DomainPropertiesVerificationStatesResponse']:
         """
         List of VerificationStatusRecord
         """

--- a/sdk/python/pulumi_azure_native/communication/email_service.py
+++ b/sdk/python/pulumi_azure_native/communication/email_service.py
@@ -119,9 +119,9 @@ class EmailService(pulumi.CustomResource):
         """
         A class representing an EmailService resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -140,9 +140,9 @@ class EmailService(pulumi.CustomResource):
         """
         A class representing an EmailService resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param EmailServiceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_azure_native/communication/get_communication_service.py
+++ b/sdk/python/pulumi_azure_native/communication/get_communication_service.py
@@ -27,13 +27,16 @@ class GetCommunicationServiceResult:
     """
     A class representing a CommunicationService resource.
     """
-    def __init__(__self__, azure_api_version=None, data_location=None, host_name=None, id=None, identity=None, immutable_resource_id=None, linked_domains=None, location=None, name=None, notification_hub_id=None, provisioning_state=None, system_data=None, tags=None, type=None, version=None):
+    def __init__(__self__, azure_api_version=None, data_location=None, disable_local_auth=None, host_name=None, id=None, identity=None, immutable_resource_id=None, linked_domains=None, location=None, name=None, notification_hub_id=None, provisioning_state=None, public_network_access=None, system_data=None, tags=None, type=None, version=None):
         if azure_api_version and not isinstance(azure_api_version, str):
             raise TypeError("Expected argument 'azure_api_version' to be a str")
         pulumi.set(__self__, "azure_api_version", azure_api_version)
         if data_location and not isinstance(data_location, str):
             raise TypeError("Expected argument 'data_location' to be a str")
         pulumi.set(__self__, "data_location", data_location)
+        if disable_local_auth and not isinstance(disable_local_auth, bool):
+            raise TypeError("Expected argument 'disable_local_auth' to be a bool")
+        pulumi.set(__self__, "disable_local_auth", disable_local_auth)
         if host_name and not isinstance(host_name, str):
             raise TypeError("Expected argument 'host_name' to be a str")
         pulumi.set(__self__, "host_name", host_name)
@@ -61,6 +64,9 @@ class GetCommunicationServiceResult:
         if provisioning_state and not isinstance(provisioning_state, str):
             raise TypeError("Expected argument 'provisioning_state' to be a str")
         pulumi.set(__self__, "provisioning_state", provisioning_state)
+        if public_network_access and not isinstance(public_network_access, str):
+            raise TypeError("Expected argument 'public_network_access' to be a str")
+        pulumi.set(__self__, "public_network_access", public_network_access)
         if system_data and not isinstance(system_data, dict):
             raise TypeError("Expected argument 'system_data' to be a dict")
         pulumi.set(__self__, "system_data", system_data)
@@ -91,6 +97,14 @@ class GetCommunicationServiceResult:
         return pulumi.get(self, "data_location")
 
     @_builtins.property
+    @pulumi.getter(name="disableLocalAuth")
+    def disable_local_auth(self) -> Optional[_builtins.bool]:
+        """
+        Disable local authentication for the CommunicationService.
+        """
+        return pulumi.get(self, "disable_local_auth")
+
+    @_builtins.property
     @pulumi.getter(name="hostName")
     def host_name(self) -> _builtins.str:
         """
@@ -110,7 +124,7 @@ class GetCommunicationServiceResult:
     @pulumi.getter
     def identity(self) -> Optional['outputs.ManagedServiceIdentityResponse']:
         """
-        Managed service identity (system assigned and/or user assigned identities)
+        The managed service identities assigned to this resource.
         """
         return pulumi.get(self, "identity")
 
@@ -163,6 +177,14 @@ class GetCommunicationServiceResult:
         return pulumi.get(self, "provisioning_state")
 
     @_builtins.property
+    @pulumi.getter(name="publicNetworkAccess")
+    def public_network_access(self) -> Optional[_builtins.str]:
+        """
+        Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.
+        """
+        return pulumi.get(self, "public_network_access")
+
+    @_builtins.property
     @pulumi.getter(name="systemData")
     def system_data(self) -> 'outputs.SystemDataResponse':
         """
@@ -203,6 +225,7 @@ class AwaitableGetCommunicationServiceResult(GetCommunicationServiceResult):
         return GetCommunicationServiceResult(
             azure_api_version=self.azure_api_version,
             data_location=self.data_location,
+            disable_local_auth=self.disable_local_auth,
             host_name=self.host_name,
             id=self.id,
             identity=self.identity,
@@ -212,6 +235,7 @@ class AwaitableGetCommunicationServiceResult(GetCommunicationServiceResult):
             name=self.name,
             notification_hub_id=self.notification_hub_id,
             provisioning_state=self.provisioning_state,
+            public_network_access=self.public_network_access,
             system_data=self.system_data,
             tags=self.tags,
             type=self.type,
@@ -224,9 +248,9 @@ def get_communication_service(communication_service_name: Optional[_builtins.str
     """
     Get the CommunicationService and its properties.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str communication_service_name: The name of the CommunicationService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.
@@ -240,6 +264,7 @@ def get_communication_service(communication_service_name: Optional[_builtins.str
     return AwaitableGetCommunicationServiceResult(
         azure_api_version=pulumi.get(__ret__, 'azure_api_version'),
         data_location=pulumi.get(__ret__, 'data_location'),
+        disable_local_auth=pulumi.get(__ret__, 'disable_local_auth'),
         host_name=pulumi.get(__ret__, 'host_name'),
         id=pulumi.get(__ret__, 'id'),
         identity=pulumi.get(__ret__, 'identity'),
@@ -249,6 +274,7 @@ def get_communication_service(communication_service_name: Optional[_builtins.str
         name=pulumi.get(__ret__, 'name'),
         notification_hub_id=pulumi.get(__ret__, 'notification_hub_id'),
         provisioning_state=pulumi.get(__ret__, 'provisioning_state'),
+        public_network_access=pulumi.get(__ret__, 'public_network_access'),
         system_data=pulumi.get(__ret__, 'system_data'),
         tags=pulumi.get(__ret__, 'tags'),
         type=pulumi.get(__ret__, 'type'),
@@ -259,9 +285,9 @@ def get_communication_service_output(communication_service_name: pulumi.Input[Op
     """
     Get the CommunicationService and its properties.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str communication_service_name: The name of the CommunicationService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.
@@ -274,6 +300,7 @@ def get_communication_service_output(communication_service_name: pulumi.Input[Op
     return __ret__.apply(lambda __response__: GetCommunicationServiceResult(
         azure_api_version=pulumi.get(__response__, 'azure_api_version'),
         data_location=pulumi.get(__response__, 'data_location'),
+        disable_local_auth=pulumi.get(__response__, 'disable_local_auth'),
         host_name=pulumi.get(__response__, 'host_name'),
         id=pulumi.get(__response__, 'id'),
         identity=pulumi.get(__response__, 'identity'),
@@ -283,6 +310,7 @@ def get_communication_service_output(communication_service_name: pulumi.Input[Op
         name=pulumi.get(__response__, 'name'),
         notification_hub_id=pulumi.get(__response__, 'notification_hub_id'),
         provisioning_state=pulumi.get(__response__, 'provisioning_state'),
+        public_network_access=pulumi.get(__response__, 'public_network_access'),
         system_data=pulumi.get(__response__, 'system_data'),
         tags=pulumi.get(__response__, 'tags'),
         type=pulumi.get(__response__, 'type'),

--- a/sdk/python/pulumi_azure_native/communication/get_domain.py
+++ b/sdk/python/pulumi_azure_native/communication/get_domain.py
@@ -180,7 +180,7 @@ class GetDomainResult:
 
     @_builtins.property
     @pulumi.getter(name="verificationRecords")
-    def verification_records(self) -> 'outputs.DomainPropertiesResponseVerificationRecords':
+    def verification_records(self) -> 'outputs.DomainPropertiesVerificationRecordsResponse':
         """
         List of DnsRecord
         """
@@ -188,7 +188,7 @@ class GetDomainResult:
 
     @_builtins.property
     @pulumi.getter(name="verificationStates")
-    def verification_states(self) -> 'outputs.DomainPropertiesResponseVerificationStates':
+    def verification_states(self) -> 'outputs.DomainPropertiesVerificationStatesResponse':
         """
         List of VerificationStatusRecord
         """
@@ -225,9 +225,9 @@ def get_domain(domain_name: Optional[_builtins.str] = None,
     """
     Get the Domains resource and its properties.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str domain_name: The name of the Domains resource.
     :param _builtins.str email_service_name: The name of the EmailService resource.
@@ -263,9 +263,9 @@ def get_domain_output(domain_name: pulumi.Input[Optional[_builtins.str]] = None,
     """
     Get the Domains resource and its properties.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str domain_name: The name of the Domains resource.
     :param _builtins.str email_service_name: The name of the EmailService resource.

--- a/sdk/python/pulumi_azure_native/communication/get_email_service.py
+++ b/sdk/python/pulumi_azure_native/communication/get_email_service.py
@@ -152,9 +152,9 @@ def get_email_service(email_service_name: Optional[_builtins.str] = None,
     """
     Get the EmailService and its properties.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str email_service_name: The name of the EmailService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.
@@ -181,9 +181,9 @@ def get_email_service_output(email_service_name: pulumi.Input[Optional[_builtins
     """
     Get the EmailService and its properties.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str email_service_name: The name of the EmailService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.

--- a/sdk/python/pulumi_azure_native/communication/get_sender_username.py
+++ b/sdk/python/pulumi_azure_native/communication/get_sender_username.py
@@ -154,9 +154,9 @@ def get_sender_username(domain_name: Optional[_builtins.str] = None,
     """
     Get a valid sender username for a domains resource.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str domain_name: The name of the Domains resource.
     :param _builtins.str email_service_name: The name of the EmailService resource.
@@ -189,9 +189,9 @@ def get_sender_username_output(domain_name: pulumi.Input[Optional[_builtins.str]
     """
     Get a valid sender username for a domains resource.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str domain_name: The name of the Domains resource.
     :param _builtins.str email_service_name: The name of the EmailService resource.

--- a/sdk/python/pulumi_azure_native/communication/get_smtp_username.py
+++ b/sdk/python/pulumi_azure_native/communication/get_smtp_username.py
@@ -141,9 +141,9 @@ def get_smtp_username(communication_service_name: Optional[_builtins.str] = None
     """
     Get a SmtpUsernameResource.
 
-    Uses Azure REST API version 2024-09-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str communication_service_name: The name of the CommunicationService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.
@@ -172,9 +172,9 @@ def get_smtp_username_output(communication_service_name: pulumi.Input[Optional[_
     """
     Get a SmtpUsernameResource.
 
-    Uses Azure REST API version 2024-09-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str communication_service_name: The name of the CommunicationService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.

--- a/sdk/python/pulumi_azure_native/communication/get_suppression_list.py
+++ b/sdk/python/pulumi_azure_native/communication/get_suppression_list.py
@@ -100,7 +100,7 @@ class GetSuppressionListResult:
     @pulumi.getter(name="listName")
     def list_name(self) -> Optional[_builtins.str]:
         """
-        The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         """
         return pulumi.get(self, "list_name")
 
@@ -154,9 +154,9 @@ def get_suppression_list(domain_name: Optional[_builtins.str] = None,
     """
     Get a SuppressionList resource.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str domain_name: The name of the Domains resource.
     :param _builtins.str email_service_name: The name of the EmailService resource.
@@ -189,9 +189,9 @@ def get_suppression_list_output(domain_name: pulumi.Input[Optional[_builtins.str
     """
     Get a SuppressionList resource.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str domain_name: The name of the Domains resource.
     :param _builtins.str email_service_name: The name of the EmailService resource.

--- a/sdk/python/pulumi_azure_native/communication/get_suppression_list_address.py
+++ b/sdk/python/pulumi_azure_native/communication/get_suppression_list_address.py
@@ -179,9 +179,9 @@ def get_suppression_list_address(address_id: Optional[_builtins.str] = None,
     """
     Get a SuppressionListAddress.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str address_id: The id of the address in a suppression list.
     :param _builtins.str domain_name: The name of the Domains resource.
@@ -219,9 +219,9 @@ def get_suppression_list_address_output(address_id: pulumi.Input[Optional[_built
     """
     Get a SuppressionListAddress.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str address_id: The id of the address in a suppression list.
     :param _builtins.str domain_name: The name of the Domains resource.

--- a/sdk/python/pulumi_azure_native/communication/list_communication_service_keys.py
+++ b/sdk/python/pulumi_azure_native/communication/list_communication_service_keys.py
@@ -91,9 +91,9 @@ def list_communication_service_keys(communication_service_name: Optional[_builti
     """
     Get the access keys of the CommunicationService resource.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str communication_service_name: The name of the CommunicationService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.
@@ -115,9 +115,9 @@ def list_communication_service_keys_output(communication_service_name: pulumi.In
     """
     Get the access keys of the CommunicationService resource.
 
-    Uses Azure REST API version 2023-06-01-preview.
+    Uses Azure REST API version 2026-03-18.
 
-    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+    Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
     :param _builtins.str communication_service_name: The name of the CommunicationService resource.
     :param _builtins.str resource_group_name: The name of the resource group. The name is case insensitive.

--- a/sdk/python/pulumi_azure_native/communication/outputs.py
+++ b/sdk/python/pulumi_azure_native/communication/outputs.py
@@ -18,8 +18,8 @@ from ._enums import *
 
 __all__ = [
     'DnsRecordResponse',
-    'DomainPropertiesResponseVerificationRecords',
-    'DomainPropertiesResponseVerificationStates',
+    'DomainPropertiesVerificationRecordsResponse',
+    'DomainPropertiesVerificationStatesResponse',
     'ManagedServiceIdentityResponse',
     'SystemDataResponse',
     'UserAssignedIdentityResponse',
@@ -83,7 +83,7 @@ class DnsRecordResponse(dict):
 
 
 @pulumi.output_type
-class DomainPropertiesResponseVerificationRecords(dict):
+class DomainPropertiesVerificationRecordsResponse(dict):
     """
     List of DnsRecord
     """
@@ -100,14 +100,14 @@ class DomainPropertiesResponseVerificationRecords(dict):
             suggest = "s_pf"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in DomainPropertiesResponseVerificationRecords. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in DomainPropertiesVerificationRecordsResponse. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        DomainPropertiesResponseVerificationRecords.__key_warning(key)
+        DomainPropertiesVerificationRecordsResponse.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        DomainPropertiesResponseVerificationRecords.__key_warning(key)
+        DomainPropertiesVerificationRecordsResponse.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,
@@ -178,7 +178,7 @@ class DomainPropertiesResponseVerificationRecords(dict):
 
 
 @pulumi.output_type
-class DomainPropertiesResponseVerificationStates(dict):
+class DomainPropertiesVerificationStatesResponse(dict):
     """
     List of VerificationStatusRecord
     """
@@ -195,14 +195,14 @@ class DomainPropertiesResponseVerificationStates(dict):
             suggest = "s_pf"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in DomainPropertiesResponseVerificationStates. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in DomainPropertiesVerificationStatesResponse. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        DomainPropertiesResponseVerificationStates.__key_warning(key)
+        DomainPropertiesVerificationStatesResponse.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        DomainPropertiesResponseVerificationStates.__key_warning(key)
+        DomainPropertiesVerificationStatesResponse.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,

--- a/sdk/python/pulumi_azure_native/communication/sender_username.py
+++ b/sdk/python/pulumi_azure_native/communication/sender_username.py
@@ -134,9 +134,9 @@ class SenderUsername(pulumi.CustomResource):
         """
         A class representing a SenderUsername resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -156,9 +156,9 @@ class SenderUsername(pulumi.CustomResource):
         """
         A class representing a SenderUsername resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-03-31.
 
-        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-03-31, 2023-04-01, 2023-04-01-preview, 2023-06-01-preview, 2024-09-01-preview, 2025-05-01, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param SenderUsernameArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_azure_native/communication/smtp_username.py
+++ b/sdk/python/pulumi_azure_native/communication/smtp_username.py
@@ -133,9 +133,9 @@ class SmtpUsername(pulumi.CustomResource):
         """
         The object describing the smtp username resource.
 
-        Uses Azure REST API version 2024-09-01-preview.
+        Uses Azure REST API version 2026-03-18.
 
-        Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -155,9 +155,9 @@ class SmtpUsername(pulumi.CustomResource):
         """
         The object describing the smtp username resource.
 
-        Uses Azure REST API version 2024-09-01-preview.
+        Uses Azure REST API version 2026-03-18.
 
-        Other available API versions: 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param SmtpUsernameArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_azure_native/communication/suppression_list.py
+++ b/sdk/python/pulumi_azure_native/communication/suppression_list.py
@@ -31,7 +31,7 @@ class SuppressionListArgs:
         :param pulumi.Input[_builtins.str] domain_name: The name of the Domains resource.
         :param pulumi.Input[_builtins.str] email_service_name: The name of the EmailService resource.
         :param pulumi.Input[_builtins.str] resource_group_name: The name of the resource group. The name is case insensitive.
-        :param pulumi.Input[_builtins.str] list_name: The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        :param pulumi.Input[_builtins.str] list_name: The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         :param pulumi.Input[_builtins.str] suppression_list_name: The name of the suppression list.
         """
         pulumi.set(__self__, "domain_name", domain_name)
@@ -82,7 +82,7 @@ class SuppressionListArgs:
     @pulumi.getter(name="listName")
     def list_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
-        The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         """
         return pulumi.get(self, "list_name")
 
@@ -118,15 +118,15 @@ class SuppressionList(pulumi.CustomResource):
         """
         A class representing a SuppressionList resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
 
-        Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] domain_name: The name of the Domains resource.
         :param pulumi.Input[_builtins.str] email_service_name: The name of the EmailService resource.
-        :param pulumi.Input[_builtins.str] list_name: The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        :param pulumi.Input[_builtins.str] list_name: The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         :param pulumi.Input[_builtins.str] resource_group_name: The name of the resource group. The name is case insensitive.
         :param pulumi.Input[_builtins.str] suppression_list_name: The name of the suppression list.
         """
@@ -139,9 +139,9 @@ class SuppressionList(pulumi.CustomResource):
         """
         A class representing a SuppressionList resource.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
 
-        Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param SuppressionListArgs args: The arguments to use to populate this resource's properties.
@@ -260,7 +260,7 @@ class SuppressionList(pulumi.CustomResource):
     @pulumi.getter(name="listName")
     def list_name(self) -> pulumi.Output[Optional[_builtins.str]]:
         """
-        The the name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
+        The name of the suppression list. This value must match one of the valid sender usernames of the sending domain.
         """
         return pulumi.get(self, "list_name")
 

--- a/sdk/python/pulumi_azure_native/communication/suppression_list_address.py
+++ b/sdk/python/pulumi_azure_native/communication/suppression_list_address.py
@@ -184,9 +184,9 @@ class SuppressionListAddress(pulumi.CustomResource):
         """
         A object that represents a SuppressionList record.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
 
-        Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -209,9 +209,9 @@ class SuppressionListAddress(pulumi.CustomResource):
         """
         A object that represents a SuppressionList record.
 
-        Uses Azure REST API version 2023-06-01-preview. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
+        Uses Azure REST API version 2026-03-18. In version 2.x of the Azure Native provider, it used API version 2023-06-01-preview.
 
-        Other available API versions: 2024-09-01-preview, 2025-05-01-preview, 2025-09-01, 2026-03-18. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
+        Other available API versions: 2023-06-01-preview, 2024-09-01-preview, 2025-05-01-preview, 2025-09-01. These can be accessed by generating a local SDK package using the CLI command `pulumi package add azure-native communication [ApiVersion]`. See the [version guide](../../../version-guide/#accessing-any-api-version-via-local-packages) for details.
 
         :param str resource_name: The name of the resource.
         :param SuppressionListAddressArgs args: The arguments to use to populate this resource's properties.

--- a/versions/v3-config.yaml
+++ b/versions/v3-config.yaml
@@ -158,8 +158,6 @@ Chaos:
 CognitiveServices:
 Commerce:
 Communication:
-  expectTracking: preview
-  notes: Only previews after initial 2020 stable release
 Compute:
   explicit: true
 ConfidentialLedger:

--- a/versions/v3-spec.yaml
+++ b/versions/v3-spec.yaml
@@ -250,9 +250,7 @@ CognitiveServices:
         listAgentApplicationAgents: 2025-10-01-preview
 Commerce: {}
 Communication:
-    tracking: 2023-06-01-preview
-    additions:
-        SmtpUsername: 2024-09-01-preview
+    tracking: "2026-03-18"
 Community:
     tracking: "2023-11-01"
 Compute:

--- a/versions/v3.yaml
+++ b/versions/v3.yaml
@@ -3549,48 +3549,48 @@ CognitiveServices:
 Commerce: {}
 Communication:
     CommunicationService:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/CommunicationServices.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/communicationServices/{communicationServiceName}
         RpNamespace: Microsoft.Communication
     Domain:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/Domains.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}
         RpNamespace: Microsoft.Communication
     EmailService:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/EmailServices.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}
         RpNamespace: Microsoft.Communication
     SenderUsername:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/SenderUsernames.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}/senderUsernames/{senderUsername}
         RpNamespace: Microsoft.Communication
     SmtpUsername:
-        ApiVersion: 2024-09-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2024-09-01-preview/SmtpUsernames.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/communicationServices/{communicationServiceName}/smtpUsernames/{smtpUsername}
         RpNamespace: Microsoft.Communication
     SuppressionList:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/SuppressionLists.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}/suppressionLists/{suppressionListName}
         RpNamespace: Microsoft.Communication
     SuppressionListAddress:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/SuppressionLists.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}/suppressionLists/{suppressionListName}/suppressionListAddresses/{addressId}
         RpNamespace: Microsoft.Communication
     listCommunicationServiceKeys:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/CommunicationServices.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/communicationServices/{communicationServiceName}/listKeys
         RpNamespace: Microsoft.Communication
     listEmailServiceVerifiedExchangeOnlineDomains:
-        ApiVersion: 2023-06-01-preview
-        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/preview/2023-06-01-preview/EmailServices.json
+        ApiVersion: "2026-03-18"
+        SpecFilePath: specification/communication/resource-manager/Microsoft.Communication/stable/2026-03-18/openapi.json
         ResourceUri: /subscriptions/{subscriptionId}/providers/Microsoft.Communication/listVerifiedExchangeOnlineDomains
         RpNamespace: Microsoft.Communication
 Community:


### PR DESCRIPTION
## Summary
Bumps the default API version for the `Communication` module from `2023-06-01-preview` to `2026-03-18`, adding `disableLocalAuth` and `publicNetworkAccess` to `CommunicationService`. Existing `SmtpUsername` addition is now covered natively by the new tracking version.

Fixes #4808