### PR TITLE
Fix Watchlist delete hanging on Azure's stuck async-operation status

### DIFF
--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -36,6 +36,9 @@ type azCoreClient struct {
 	// Exposed internally for tests, to set it at the minimum value for fast tests.
 	deletePollingIntervalSeconds int64
 	updatePollingIntervalSeconds int64
+	// Number of deletePollingIntervalSeconds to wait before falling back to GET-based
+	// delete confirmation. Exposed for tests.
+	deleteConfirmGraceIntervals int64
 
 	// Serialization for resources that have hit "exclusive lock" 429 errors.
 	// Maps serialization key (e.g., App Service Plan ID) to a mutex that serializes operations.
@@ -116,6 +119,7 @@ func NewAzCoreClient(tokenCredential azcore.TokenCredential, extraUserAgent stri
 		extraUserAgent:               extraUserAgent,
 		deletePollingIntervalSeconds: 30, // same as autorest.DefaultPollingDelay
 		updatePollingIntervalSeconds: 10,
+		deleteConfirmGraceIntervals:  4,
 		serializationsMap:            make(map[string]*sync.Mutex),
 	}, nil
 }
@@ -261,6 +265,9 @@ func (c *azCoreClient) Delete(ctx context.Context, id, apiVersion, asyncStyle st
 			if err != nil {
 				return err
 			}
+			if isWatchlistDelete(id) {
+				return c.pollDeleteUntilDoneOrGone(ctx, pt, id, apiVersion)
+			}
 			_, err = pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
 				Frequency: time.Duration(c.deletePollingIntervalSeconds * int64(time.Second)),
 			})
@@ -275,6 +282,70 @@ func (c *azCoreClient) Delete(ctx context.Context, id, apiVersion, asyncStyle st
 		}
 		return newResponseError(err.RawResponse)
 	}
+	return err
+}
+
+// watchlistResourcePattern matches Microsoft.SecurityInsights/watchlists resource IDs.
+const watchlistResourcePattern = "/providers/microsoft.securityinsights/watchlists/"
+
+func isWatchlistDelete(id string) bool {
+	return strings.Contains(strings.ToLower(id), watchlistResourcePattern)
+}
+
+func isStatusNotFound(err error) bool {
+	switch e := err.(type) {
+	case *azcore.ResponseError:
+		return e.StatusCode == http.StatusNotFound
+	case *PulumiAzcoreResponseError:
+		return e.StatusCode == http.StatusNotFound
+	default:
+		return false
+	}
+}
+
+// pollDeleteUntilDoneOrGone works around a confirmed Azure service bug where deleting a
+// Watchlist never reports a terminal status on its async-operation status monitor, even after
+// the resource itself is gone. It races the normal LRO poll against an independent GET on the
+// resource, falling back to a 404 there after a grace period. See #4816 and
+// Azure/azure-sdk-for-go#26937. Remove once Azure fixes the underlying behavior.
+func (c *azCoreClient) pollDeleteUntilDoneOrGone(ctx context.Context, pt *runtime.Poller[any], id, apiVersion string) error {
+	pollCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make(chan error, 2)
+	interval := time.Duration(c.deletePollingIntervalSeconds) * time.Second
+
+	go func() {
+		_, err := pt.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{Frequency: interval})
+		results <- err
+	}()
+
+	go func() {
+		grace := interval * time.Duration(c.deleteConfirmGraceIntervals)
+		select {
+		case <-pollCtx.Done():
+			return
+		case <-time.After(grace):
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pollCtx.Done():
+				return
+			case <-ticker.C:
+				// Not using IsNotFound: this endpoint returns ErrorCode "404" rather than a
+				// recognized semantic code, so check the status directly.
+				if _, err := c.Get(pollCtx, id, apiVersion, nil); isStatusNotFound(err) {
+					results <- nil
+					return
+				}
+			}
+		}
+	}()
+
+	err := <-results
+	cancel()
 	return err
 }
 

--- a/provider/pkg/azure/client_azcore_test.go
+++ b/provider/pkg/azure/client_azcore_test.go
@@ -894,3 +894,28 @@ func TestNewResponseError(t *testing.T) {
 		assert.False(t, IsNotFound(newResponseError(resp)))
 	})
 }
+
+func TestIsWatchlistDelete(t *testing.T) {
+	watchlistID := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.OperationalInsights/" +
+		"workspaces/ws/providers/Microsoft.SecurityInsights/Watchlists/my-watchlist"
+	assert.True(t, isWatchlistDelete(watchlistID))
+
+	otherID := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage"
+	assert.False(t, isWatchlistDelete(otherID))
+}
+
+func TestIsStatusNotFound(t *testing.T) {
+	// Watchlist's own 404 uses ErrorCode "404" rather than a recognized semantic code like
+	// "ResourceNotFound" -- IsNotFound rejects that, so the delete fallback checks the status
+	// code directly instead. See #4816.
+	resp := &http.Response{
+		StatusCode: 404,
+		Body:       io.NopCloser(strings.NewReader(`{"error": {"code": "404", "message": "does not exist"}}`)),
+	}
+	err := newResponseError(resp)
+	assert.False(t, IsNotFound(err))
+	assert.True(t, isStatusNotFound(err))
+
+	assert.False(t, isStatusNotFound(nil))
+	assert.False(t, isStatusNotFound(errors.New("some other error")))
+}

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/version"
@@ -566,6 +567,29 @@ func TestDatabricksWorkspaceComputeModeDefault(t *testing.T) {
 		serverlessSummary[apitype.OpDeleteReplaced]
 	assert.Greater(t, replacementOpsServerless, 0,
 		"expected a replacement when changing computeMode from Hybrid to Serverless")
+}
+
+// TestSecurityInsightsWatchlistDelete is a regression test for issue #4816: Azure's delete
+// status monitor for a Watchlist never reports a terminal state, even though the resource
+// itself is deleted within seconds. Without the GET-based fallback this hangs until the
+// provider's delete timeout. See Azure/azure-sdk-for-go#26937 for the confirmed upstream bug.
+func TestSecurityInsightsWatchlistDelete(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "watchlist-delete/step1")
+	defer func() {
+		pt.Destroy(t)
+	}()
+	pt.Up(t)
+
+	pt.UpdateSource(t, "test-programs", "watchlist-delete", "step2")
+	start := time.Now()
+	up := pt.Up(t)
+	elapsed := time.Since(start)
+
+	upSummary := changesummary.FromStringIntMap(*up.Summary.ResourceChanges)
+	assert.Equal(t, 1, upSummary[apitype.OpDelete], "expected the watchlist to be deleted")
+	assert.Less(t, elapsed, 10*time.Minute,
+		"delete took too long, the GET-based fallback may not be engaging")
 }
 
 // TestStorageAccountSingletonChildAfterReplace is a regression test for issue #4738: replacing a

--- a/provider/pkg/provider/test-programs/watchlist-delete/step1/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/watchlist-delete/step1/Pulumi.yaml
@@ -1,0 +1,42 @@
+name: watchlist-delete
+runtime: yaml
+description: |
+  Regression test for issue #4816: deleting a securityinsights Watchlist used to hang
+  because Azure's delete status monitor never reports a terminal state, even though the
+  resource itself is already gone. step1: create the workspace and watchlist.
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  workspace:
+    type: azure-native:operationalinsights:Workspace
+    properties:
+      resourceGroupName: ${rg.name}
+      retentionInDays: 30
+      sku:
+        name: PerGB2018
+
+  onboardingState:
+    type: azure-native:securityinsights:SentinelOnboardingState
+    properties:
+      resourceGroupName: ${rg.name}
+      workspaceName: ${workspace.name}
+      customerManagedKey: false
+      sentinelOnboardingStateName: default
+
+  watchlist:
+    type: azure-native:securityinsights:Watchlist
+    properties:
+      resourceGroupName: ${rg.name}
+      workspaceName: ${workspace.name}
+      displayName: Test watchlist
+      itemsSearchKey: AssetName
+      contentType: text/csv
+      provider: Microsoft
+      source: watchlist.csv
+      sourceType: Local
+      rawContent: "AssetName,IPAddress\nweb-01,10.0.1.10"
+    options:
+      dependsOn:
+        - ${onboardingState}

--- a/provider/pkg/provider/test-programs/watchlist-delete/step2/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/watchlist-delete/step2/Pulumi.yaml
@@ -1,0 +1,24 @@
+name: watchlist-delete
+runtime: yaml
+description: |
+  step2: remove the watchlist, triggering the delete path under test. See step1 for context.
+
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  workspace:
+    type: azure-native:operationalinsights:Workspace
+    properties:
+      resourceGroupName: ${rg.name}
+      retentionInDays: 30
+      sku:
+        name: PerGB2018
+
+  onboardingState:
+    type: azure-native:securityinsights:SentinelOnboardingState
+    properties:
+      resourceGroupName: ${rg.name}
+      workspaceName: ${workspace.name}
+      customerManagedKey: false
+      sentinelOnboardingStateName: default


### PR DESCRIPTION
Deleting a `securityinsights.Watchlist` could hang for a long time: Azure's delete status monitor never reports a terminal state, even though the resource is actually deleted within seconds (confirmed live, and tracked upstream in [Azure/azure-sdk-for-go#26937](https://github.com/Azure/azure-sdk-for-go/issues/26937)).

Adds a GET-based fallback, scoped to Watchlist only, that confirms deletion via a 404 on the resource itself after a grace period, independent of the broken status monitor.

Fixes #4816