### PR TITLE
Fix #4815: honor cloud config in custom resource ARM clients

### DIFF
--- a/provider/pkg/resources/customresources/custom_pim_eligibility.go
+++ b/provider/pkg/resources/customresources/custom_pim_eligibility.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure/cloud"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/provider/crud"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/resources"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/util"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 	"github.com/google/uuid"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -63,6 +65,7 @@ func pimRoleEligibilitySchedule(
 	lookupResource resources.ResourceLookupFunc,
 	crudClientFactory crud.ResourceCrudClientFactory,
 	token azcore.TokenCredential,
+	env cloud.Configuration,
 ) (*CustomResource, error) {
 	// This func's parameters are all nil when the function is called for the first time, for
 	// `customresources.featureLookup`, so we initialize the objects we need conditionally
@@ -83,11 +86,16 @@ func pimRoleEligibilitySchedule(
 		}
 		crudClient = crudClientFactory(&res)
 
-		schedulesClient, err = armauthorization.NewRoleEligibilitySchedulesClient(token, nil)
+		clientOptions := &arm.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: env.Configuration,
+			},
+		}
+		schedulesClient, err = armauthorization.NewRoleEligibilitySchedulesClient(token, clientOptions)
 		if err != nil {
 			return nil, err
 		}
-		requestsClient, err = armauthorization.NewRoleEligibilityScheduleRequestsClient(token, nil)
+		requestsClient, err = armauthorization.NewRoleEligibilityScheduleRequestsClient(token, clientOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/pkg/resources/customresources/custom_recoveryservices.go
+++ b/provider/pkg/resources/customresources/custom_recoveryservices.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	recovery "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
 
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure/cloud"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/provider/crud"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -45,8 +47,13 @@ type protectedItemProperties struct {
 // A custom resource for Microsoft.RecoveryServices ProtectedItem, specifically the file share protected item. It looks
 // up the magic "system name" of the file share and adds it to the inputs. For other types of protected items, it does
 // nothing. #1420
-func recoveryServicesProtectedItem(subscription string, cred azcore.TokenCredential) (*CustomResource, error) {
-	clientFactory, err := recovery.NewClientFactory(subscription, cred, nil)
+func recoveryServicesProtectedItem(subscription string, cred azcore.TokenCredential, env cloud.Configuration) (*CustomResource, error) {
+	clientOptions := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: env.Configuration,
+		},
+	}
+	clientFactory, err := recovery.NewClientFactory(subscription, cred, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create recovery services client factory: %w", err)
 	}

--- a/provider/pkg/resources/customresources/custom_roleassignment.go
+++ b/provider/pkg/resources/customresources/custom_roleassignment.go
@@ -8,8 +8,10 @@ import (
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure"
+	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/azure/cloud"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/provider/crud"
 	"github.com/pulumi/pulumi-azure-native/v2/provider/pkg/resources"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -68,6 +70,7 @@ func roleAssignment(
 	crudClientFactory crud.ResourceCrudClientFactory,
 	azureClient azure.AzureClient,
 	tokenCred azcore.TokenCredential,
+	env cloud.Configuration,
 ) (*CustomResource, error) {
 	// This func's parameters are all nil when the function is called for the first time, for
 	// `customresources.featureLookup`, so we initialize the objects we need conditionally
@@ -86,7 +89,11 @@ func roleAssignment(
 		}
 		crudClient := crudClientFactory(&res)
 
-		subsClient, err := armsubscriptions.NewClient(tokenCred, nil)
+		subsClient, err := armsubscriptions.NewClient(tokenCred, &arm.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: env.Configuration,
+			},
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/provider/pkg/resources/customresources/customresources.go
+++ b/provider/pkg/resources/customresources/customresources.go
@@ -207,7 +207,11 @@ func BuildCustomResources(
 
 	logging.V(9).Infof("building custom resources for cloud %q", cloud.Name)
 
-	armKVClient, err := armkeyvault.NewVaultsClient(subscriptionID, tokenCred, &arm.ClientOptions{})
+	armKVClient, err := armkeyvault.NewVaultsClient(subscriptionID, tokenCred, &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +230,7 @@ func BuildCustomResources(
 		return nil, err
 	}
 
-	protectedItem, err := recoveryServicesProtectedItem(subscriptionID, tokenCred)
+	protectedItem, err := recoveryServicesProtectedItem(subscriptionID, tokenCred, cloud)
 	if err != nil {
 		return nil, err
 	}
@@ -236,12 +240,12 @@ func BuildCustomResources(
 		return nil, err
 	}
 
-	pimRoleEligibilitySchedule, err := pimRoleEligibilitySchedule(lookupResource, crudClientFactory, tokenCred)
+	pimRoleEligibilitySchedule, err := pimRoleEligibilitySchedule(lookupResource, crudClientFactory, tokenCred, cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	customRoleAssignment, err := roleAssignment(lookupResource, crudClientFactory, azureClient, tokenCred)
+	customRoleAssignment, err := roleAssignment(lookupResource, crudClientFactory, azureClient, tokenCred, cloud)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Fixes four custom-resource client constructions (recovery services, keyvault access policy, PIM eligibility, role assignment) that built ARM clients with nil/zero `ClientOptions`, silently sending calls to commercial ARM on sovereign clouds.
- Threads the configured `cloud.Configuration` through, matching the pattern already used in `custom_storage_azidentity.go` (#3991).

Fixes #4815