### PR TITLE
Give each parameterized package its own Go module

### DIFF
--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -8,7 +8,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -243,6 +245,11 @@ func getAvailableApiVersions(schema pschema.PackageSpec, targetModule string) []
 func createSchema(p *azureNativeProvider, schema pschema.PackageSpec, targetModule, targetApiVersion string) (*pschema.PackageSpec, *resources.APIMetadata, error) {
 	newPackageName := generateNewPackageName(schema.Name, targetModule, targetApiVersion)
 
+	language, err := parameterizedLanguage(schema.Language, newPackageName)
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
 	newSchema := pschema.PackageSpec{
 		Name:        newPackageName,
 		Version:     schema.Version,
@@ -255,7 +262,7 @@ func createSchema(p *azureNativeProvider, schema pschema.PackageSpec, targetModu
 		Repository:  schema.Repository,
 		Config:      schema.Config,
 		Provider:    schema.Provider,
-		Language:    schema.Language,
+		Language:    language,
 		Types:       map[string]pschema.ComplexTypeSpec{},
 		Resources:   map[string]pschema.ResourceSpec{},
 		Functions:   map[string]pschema.FunctionSpec{},
@@ -348,6 +355,46 @@ func createSchema(p *azureNativeProvider, schema pschema.PackageSpec, targetModu
 	}
 
 	return &newSchema, metadata, nil
+}
+
+// parameterizedLanguage adapts the base provider's language options to the parameterized package. Only Go needs a
+// change: its options encode the module identity of the published monolithic SDK, which the locally generated SDK
+// must not claim. See https://github.com/pulumi/pulumi-azure-native/issues/4826.
+func parameterizedLanguage(base map[string]pschema.RawMessage, newPackageName string,
+) (map[string]pschema.RawMessage, error) {
+	goOptions, ok := base["go"]
+	if !ok {
+		return base, nil
+	}
+
+	var options map[string]any
+	if err := json.Unmarshal(goOptions, &options); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal Go language options: %w", err)
+	}
+	if importBasePath, ok := options["importBasePath"].(string); ok {
+		options["importBasePath"] = parameterizedGoImportBasePath(importBasePath, newPackageName)
+	}
+	// Both options name the published per-service modules, which a parameterized package does not use.
+	delete(options, "importPathPattern")
+	delete(options, "packageImportAliases")
+
+	marshalled, err := json.Marshal(options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Go language options: %w", err)
+	}
+
+	language := maps.Clone(base)
+	language["go"] = marshalled
+	return language, nil
+}
+
+// parameterizedGoImportBasePath gives the parameterized package its own Go module. Codegen reads the module path of
+// the generated SDK from the parent of the import base path, and the root of its source tree from the last segment.
+// Inserting the package name between the two mirrors the layout of the published per-service modules, e.g.
+// `github.com/pulumi/pulumi-azure-native-sdk/v3` becomes
+// `github.com/pulumi/pulumi-azure-native-sdk/azure-native_storage_v20250101/v3`.
+func parameterizedGoImportBasePath(baseImportBasePath, newPackageName string) string {
+	return path.Join(path.Dir(baseImportBasePath), newPackageName, path.Base(baseImportBasePath))
 }
 
 // filterTokens returns a map of tokens that match the target module and API version.

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -507,3 +507,47 @@ func TestCreateSchemaErrorChecking(t *testing.T) {
 		assert.Contains(t, err.Error(), "module compute not found. Some modules were renamed in v3 of the provider")
 	})
 }
+
+func TestParameterizedLanguage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("go options are rewritten for the new package", func(t *testing.T) {
+		t.Parallel()
+
+		baseGoOptions := pschema.RawMessage(`{
+			"importBasePath": "github.com/pulumi/pulumi-azure-native-sdk/v3",
+			"importPathPattern": "github.com/pulumi/pulumi-azure-native-sdk/{module}/v3",
+			"packageImportAliases": {"github.com/pulumi/pulumi-azure-native-sdk/storage/v3": "storage"},
+			"internalModuleName": "utilities",
+			"rootPackageName": "pulumiazurenativesdk"
+		}`)
+		base := map[string]pschema.RawMessage{
+			"go":     baseGoOptions,
+			"nodejs": pschema.RawMessage(`{"respectSchemaVersion": true}`),
+		}
+
+		language, err := parameterizedLanguage(base, "azure-native_storage_v20250101")
+		require.NoError(t, err)
+
+		var goOptions map[string]any
+		require.NoError(t, json.Unmarshal(language["go"], &goOptions))
+		assert.Equal(t, map[string]any{
+			"importBasePath":     "github.com/pulumi/pulumi-azure-native-sdk/azure-native_storage_v20250101/v3",
+			"internalModuleName": "utilities",
+			"rootPackageName":    "pulumiazurenativesdk",
+		}, goOptions)
+
+		assert.Equal(t, pschema.RawMessage(`{"respectSchemaVersion": true}`), language["nodejs"])
+		// The base options belong to the unparameterized provider and must not change.
+		assert.Equal(t, baseGoOptions, base["go"])
+	})
+
+	t.Run("no go options", func(t *testing.T) {
+		t.Parallel()
+
+		base := map[string]pschema.RawMessage{"nodejs": []byte(`{}`)}
+		language, err := parameterizedLanguage(base, "azure-native_storage_v20250101")
+		require.NoError(t, err)
+		assert.Equal(t, base, language)
+	})
+}


### PR DESCRIPTION
Fixes #4826

### Problem

`Parameterize` copied the base provider's `language` options into the sub-schema. The Go options name the published monolithic SDK:

```json
"importBasePath": "github.com/pulumi/pulumi-azure-native-sdk/v3"
```

Codegen reads the module path of a generated SDK from the parent of that path, and the root of its source tree from the last segment. The SDK from `pulumi package add` therefore became module `github.com/pulumi/pulumi-azure-native-sdk` with sources under `v3/`, and it emitted `v3/utilities`. The published root module `github.com/pulumi/pulumi-azure-native-sdk/v3` supplies that same package, and every published service module requires it. Go then found one package in two modules:

```console
$ go mod tidy
github.com/pulumi/pulumi-azure-native-sdk/v3/utilities: ambiguous import: found package
  github.com/pulumi/pulumi-azure-native-sdk/v3/utilities in multiple modules:
	github.com/pulumi/pulumi-azure-native-sdk v0.0.0-... (./sdks/.../v3/utilities)
	github.com/pulumi/pulumi-azure-native-sdk/v3 v3.27.0 (~/go/pkg/mod/.../v3@v3.27.0/utilities)
```

When the published root module is not yet a requirement, the build succeeds but the local SDK shadows `github.com/pulumi/pulumi-azure-native-sdk/v3/...` for every published module in the program.

### Fix

Rewrite the Go options for the parameterized package. Insert the package name before the version segment, which mirrors the layout of the published per-service modules:

```
github.com/pulumi/pulumi-azure-native-sdk/azure-native_containerregistry_v20260101preview/v3
```

The new path comes from the schema, not from a new constant, so it follows `goBasePath` in `pkg/gen`. Also drop `importPathPattern` and `packageImportAliases`, because both name the published service modules.

A simpler option is to drop `importBasePath` as well. Do not do this. Codegen then derives the module path from the repository and the major version only, so every parameterized package gets the path `github.com/pulumi/pulumi-azure-native/sdk/go/v3`. A second `pulumi package add` overwrites the `replace` directive of the first, and the first package becomes unreachable.

### Verification

Build the provider, then run the reporter's sequence. Start from a program that imports `github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3`, so that `go mod tidy` records the published root module. Add the parameterized package, then build.

With v3.27.0 the build fails with the ambiguous import above. With this change `go mod tidy` and `go build` are clean, and the local SDK, `containerregistry/v3` and the published root module coexist:

```console
$ grep azure-native-sdk go.mod
	github.com/pulumi/pulumi-azure-native-sdk/azure-native_containerregistry_v20260101preview v0.0.0-...
	github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.27.0
	github.com/pulumi/pulumi-azure-native-sdk/v3 v3.27.0 // indirect
replace github.com/pulumi/pulumi-azure-native-sdk/azure-native_containerregistry_v20260101preview => ./sdks/azure-native_containerregistry_v20260101preview
```

### Note

The import path that `pulumi package add` prints is still wrong. It comes from `codegen.ExtractImportBasePath`, which ignores `importBasePath`. That is a CLI defect, tracked in pulumi/pulumi#24433.