### PR TITLE
Fix #4825: don't send NamespaceNetworkRuleSet's publicNetworkAccess default

### DIFF
--- a/provider/pkg/gen/properties_test.go
+++ b/provider/pkg/gen/properties_test.go
@@ -152,6 +152,13 @@ func TestNoDefault(t *testing.T) {
 	assert.False(t, otherModule.noDefault("http20ProxyFlag"))
 	assert.False(t, otherResource.noDefault("reserved"))
 	assert.False(t, otherModule.noDefault("reserved"))
+
+	ruleSet := moduleGenerator{moduleName: "ServiceBus", resourceName: "NamespaceNetworkRuleSet"}
+	// The parent namespace keeps its own publicNetworkAccess default.
+	namespace := moduleGenerator{moduleName: "ServiceBus", resourceName: "Namespace"}
+	assert.True(t, ruleSet.noDefault("publicNetworkAccess"))
+	assert.False(t, ruleSet.noDefault("defaultAction"))
+	assert.False(t, namespace.noDefault("publicNetworkAccess"))
 }
 
 func TestIsReadableOutput(t *testing.T) {

--- a/provider/pkg/gen/replacement.go
+++ b/provider/pkg/gen/replacement.go
@@ -157,6 +157,17 @@ var caseInsensitiveDiffMap = map[openapi.ModuleName]map[string]codegen.StringSet
 // rejects (or misbehaves on) receiving the spec's own default value, i.e. that the spec documents a
 // default the RP won't actually accept on the wire for every flavour of the resource.
 var noDefaultMap = map[openapi.ModuleName]map[string]codegen.StringSet{
+	"ServiceBus": {
+		// The networkRuleSets/default sub-resource shares its publicNetworkAccess with the parent
+		// namespace: they are one and the same setting. The spec's `default: "Enabled"` makes the
+		// SDKs put "Enabled" in every PUT body, so applying a NamespaceNetworkRuleSet that only
+		// meant to change e.g. trustedServiceAccessEnabled silently re-enables public access on a
+		// namespace configured as Disabled. Verified live that omitting the property from the ARM
+		// PUT preserves the namespace's current value instead (and that sending "Enabled" flips it,
+		// or is rejected outright when defaultAction is Deny). See
+		// https://github.com/pulumi/pulumi-azure-native/issues/4825.
+		"NamespaceNetworkRuleSet": codegen.NewStringSet("publicNetworkAccess"),
+	},
 	"Web": {
 		// siteConfig.http20ProxyFlag was added to Microsoft.Web/sites in API version 2024-11-01
 		// with a spec default of 0, which the SDKs then send on every request. Azure Functions on

--- a/sdk/dotnet/ServiceBus/NamespaceNetworkRuleSet.cs
+++ b/sdk/dotnet/ServiceBus/NamespaceNetworkRuleSet.cs
@@ -195,7 +195,6 @@ namespace Pulumi.AzureNative.ServiceBus
 
         public NamespaceNetworkRuleSetArgs()
         {
-            PublicNetworkAccess = "Enabled";
         }
         public static new NamespaceNetworkRuleSetArgs Empty => new NamespaceNetworkRuleSetArgs();
     }

--- a/sdk/nodejs/servicebus/namespaceNetworkRuleSet.ts
+++ b/sdk/nodejs/servicebus/namespaceNetworkRuleSet.ts
@@ -102,7 +102,7 @@ export class NamespaceNetworkRuleSet extends pulumi.CustomResource {
             resourceInputs["defaultAction"] = args?.defaultAction;
             resourceInputs["ipRules"] = args?.ipRules;
             resourceInputs["namespaceName"] = args?.namespaceName;
-            resourceInputs["publicNetworkAccess"] = (args?.publicNetworkAccess) ?? "Enabled";
+            resourceInputs["publicNetworkAccess"] = args?.publicNetworkAccess;
             resourceInputs["resourceGroupName"] = args?.resourceGroupName;
             resourceInputs["trustedServiceAccessEnabled"] = args?.trustedServiceAccessEnabled;
             resourceInputs["virtualNetworkRules"] = args?.virtualNetworkRules;

--- a/sdk/python/pulumi_azure_native/servicebus/namespace_network_rule_set.py
+++ b/sdk/python/pulumi_azure_native/servicebus/namespace_network_rule_set.py
@@ -46,8 +46,6 @@ class NamespaceNetworkRuleSetArgs:
             pulumi.set(__self__, "default_action", default_action)
         if ip_rules is not None:
             pulumi.set(__self__, "ip_rules", ip_rules)
-        if public_network_access is None:
-            public_network_access = 'Enabled'
         if public_network_access is not None:
             pulumi.set(__self__, "public_network_access", public_network_access)
         if trusted_service_access_enabled is not None:
@@ -220,8 +218,6 @@ class NamespaceNetworkRuleSet(pulumi.CustomResource):
             if namespace_name is None and not opts.urn:
                 raise TypeError("Missing required property 'namespace_name'")
             __props__.__dict__["namespace_name"] = namespace_name
-            if public_network_access is None:
-                public_network_access = 'Enabled'
             __props__.__dict__["public_network_access"] = public_network_access
             if resource_group_name is None and not opts.urn:
                 raise TypeError("Missing required property 'resource_group_name'")


### PR DESCRIPTION
Fixes #4825.

`servicebus.NamespaceNetworkRuleSet` shares `publicNetworkAccess` with its parent namespace — one and the same setting. The spec's `default: "Enabled"` made every SDK put `"Enabled"` in the PUT body, so a rule set that only meant to set `trustedServiceAccessEnabled` silently **re-enabled public network access** on a namespace configured as `Disabled`. With `defaultAction: Deny` it failed outright (`InvalidNetworkRuleSetUpdate`).

Dropping the default via `noDefaultMap` means the property is now only sent when explicitly set, and Azure preserves the namespace's current value.

## Verified against live Azure

| PUT to `networkrulesets/default` | Namespace `publicNetworkAccess` |
|---|---|
| omitting the property | `Disabled` — preserved |
| explicit `"Enabled"` (old SDK) | `Enabled` — **flipped** |

Reproduced end-to-end with `pulumi up` on v3.27.0, then confirmed fixed.

## Upgrade note

Existing stacks recorded `publicNetworkAccess: "Enabled"` as an input, so the first preview after upgrading shows one update dropping it. Verified live that this update changes nothing in Azure and clears the stale value from state; the next preview is clean.

Note `defaultAction: Deny` with no IP/VNet rules still requires `publicNetworkAccess: "Disabled"` to be set explicitly — the RP validates the request body rather than the effective value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)