### PR TITLE
Fix #4484: recognize StorageAccountNotFound as a "not found" error

### DIFF
--- a/provider/pkg/azure/azure.go
+++ b/provider/pkg/azure/azure.go
@@ -57,6 +57,9 @@ func IsNotFound(err error) bool {
 		"EntityNotFound":         true,
 		"SubscriptionNotFound":   true,
 		"RoleAssignmentNotFound": true,
+		// A storage account's PUT is accepted with a 202 and can still fail asynchronously, after
+		// which Azure rolls the account back. See pulumi/pulumi-azure-native#4484.
+		"StorageAccountNotFound": true,
 		// For resources of type azure-native:sql:DatabaseVulnerabilityAssessmentRuleBaseline
 		// See pulumi/pulumi-azure-native#4721 for more details
 		"VulnerabilityAssessmentBaselineDoesNotExists": true,

--- a/provider/pkg/azure/azure_test.go
+++ b/provider/pkg/azure/azure_test.go
@@ -53,7 +53,7 @@ func TestBuildUserAgent(t *testing.T) {
 func TestIsNotFound(t *testing.T) {
 	t.Run("azcore with valid error code", func(t *testing.T) {
 		// Test all valid "not found" error codes
-		validCodes := []string{"NotFound", "ResourceNotFound", "ResourceGroupNotFound", "LockNotFound"}
+		validCodes := []string{"NotFound", "ResourceNotFound", "ResourceGroupNotFound", "LockNotFound", "StorageAccountNotFound"}
 		for _, code := range validCodes {
 			assert.True(t, IsNotFound(&azcore.ResponseError{
 				StatusCode: http.StatusNotFound,
@@ -87,7 +87,7 @@ func TestIsNotFound(t *testing.T) {
 
 	t.Run("provider with valid error code", func(t *testing.T) {
 		// Test all valid "not found" error codes
-		validCodes := []string{"NotFound", "ResourceNotFound", "ResourceGroupNotFound", "LockNotFound"}
+		validCodes := []string{"NotFound", "ResourceNotFound", "ResourceGroupNotFound", "LockNotFound", "StorageAccountNotFound"}
 		for _, code := range validCodes {
 			assert.True(t, IsNotFound(&PulumiAzcoreResponseError{
 				StatusCode: http.StatusNotFound,

--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -5,6 +5,7 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -430,6 +431,9 @@ func (c *azCoreClient) putOrPatch(ctx context.Context, method string, id string,
 			}
 			return nil, created, err
 		}
+		if err := failedOperationError(outputs); err != nil {
+			return nil, created, err
+		}
 	}
 
 	return outputs, true, nil
@@ -709,6 +713,45 @@ func newResponseError(resp *http.Response) error {
 		Message:    errMsg,
 		Details:    details,
 	}
+}
+
+// failedOperationError returns an error if the given body is a long-running operation status
+// envelope that reports a terminal failure, and nil otherwise. azcore's Location-header poller
+// derives the operation's state from the HTTP status code alone, so an operation that answers a
+// poll with 200 and `"status": "Failed"` in the body is otherwise taken for a success and its
+// failure is handed back as the resource's outputs. See pulumi/pulumi-azure-native#4484.
+//
+// A failure envelope is required to carry an `error` object, which also keeps this from mistaking
+// a resource whose own state happens to be reported as failed for a failed operation.
+func failedOperationError(body map[string]any) error {
+	status, ok := body["status"].(string)
+	if !ok {
+		return nil
+	}
+	switch strings.ToLower(status) {
+	case "failed", "canceled", "cancelled":
+	default:
+		return nil
+	}
+
+	errorBody, ok := util.GetInnerMap(body, "error")
+	if !ok {
+		return nil
+	}
+	code, _ := errorBody["code"].(string)
+	message, _ := errorBody["message"].(string)
+	if code == "" && message == "" {
+		return nil
+	}
+
+	parts := []string{fmt.Sprintf("the operation completed with status %q", status)}
+	if code != "" {
+		parts = append(parts, fmt.Sprintf("Code=%q", code))
+	}
+	if message != "" {
+		parts = append(parts, fmt.Sprintf("Message=%q", message))
+	}
+	return errors.New(strings.Join(parts, " "))
 }
 
 type PulumiAzcoreErrorDetail struct {

--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -262,17 +262,23 @@ func (c *azCoreClient) Delete(ctx context.Context, id, apiVersion, asyncStyle st
 		// Some APIs are explicitly marked `x-ms-long-running-operation` and we should only do the
 		// poll for the deletion result in that case.
 		if asyncStyle != "" {
-			pt, err := runtime.NewPoller[any](resp, c.pipeline, nil)
+			pt, err := runtime.NewPoller[map[string]any](resp, c.pipeline, nil)
 			if err != nil {
 				return err
 			}
 			if isWatchlistDelete(id) {
+				// Deliberately not checking the operation's status here: this path already races the
+				// poll against a GET that confirms the watchlist is gone, precisely because the API
+				// misreports the deletion. See #4816.
 				return c.pollDeleteUntilDoneOrGone(ctx, pt, id, apiVersion)
 			}
-			_, err = pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+			result, err := pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
 				Frequency: time.Duration(c.deletePollingIntervalSeconds * int64(time.Second)),
 			})
-			return err
+			if err != nil {
+				return err
+			}
+			return failedOperationError(result)
 		}
 		return nil
 	}()
@@ -309,7 +315,7 @@ func isStatusNotFound(err error) bool {
 // the resource itself is gone. It races the normal LRO poll against an independent GET on the
 // resource, falling back to a 404 there after a grace period. See #4816 and
 // Azure/azure-sdk-for-go#26937. Remove once Azure fixes the underlying behavior.
-func (c *azCoreClient) pollDeleteUntilDoneOrGone(ctx context.Context, pt *runtime.Poller[any], id, apiVersion string) error {
+func (c *azCoreClient) pollDeleteUntilDoneOrGone(ctx context.Context, pt *runtime.Poller[map[string]any], id, apiVersion string) error {
 	pollCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -718,8 +724,9 @@ func newResponseError(resp *http.Response) error {
 // failedOperationError returns an error if the given body is a long-running operation status
 // envelope that reports a terminal failure, and nil otherwise. azcore's Location-header poller
 // derives the operation's state from the HTTP status code alone, so an operation that answers a
-// poll with 200 and `"status": "Failed"` in the body is otherwise taken for a success and its
-// failure is handed back as the resource's outputs. See pulumi/pulumi-azure-native#4484.
+// poll with 200 and `"status": "Failed"` in the body is otherwise taken for a success: a create
+// hands the failure back as the resource's outputs, and a delete reports a resource that is still
+// there as gone. See pulumi/pulumi-azure-native#4484.
 //
 // A failure envelope is required to carry an `error`, which also keeps this from mistaking a
 // resource whose own state happens to be reported as failed for a failed operation: plenty of

--- a/provider/pkg/azure/client_azcore.go
+++ b/provider/pkg/azure/client_azcore.go
@@ -721,8 +721,10 @@ func newResponseError(resp *http.Response) error {
 // poll with 200 and `"status": "Failed"` in the body is otherwise taken for a success and its
 // failure is handed back as the resource's outputs. See pulumi/pulumi-azure-native#4484.
 //
-// A failure envelope is required to carry an `error` object, which also keeps this from mistaking
-// a resource whose own state happens to be reported as failed for a failed operation.
+// A failure envelope is required to carry an `error`, which also keeps this from mistaking a
+// resource whose own state happens to be reported as failed for a failed operation: plenty of
+// resources have a `status` that can be "Failed" - a job run, a restore, a compilation - and carry
+// no `error` alongside it.
 func failedOperationError(body map[string]any) error {
 	status, ok := body["status"].(string)
 	if !ok {
@@ -734,12 +736,16 @@ func failedOperationError(body map[string]any) error {
 		return nil
 	}
 
-	errorBody, ok := util.GetInnerMap(body, "error")
-	if !ok {
-		return nil
+	var code, message string
+	switch errorBody := body["error"].(type) {
+	case map[string]any:
+		code, _ = errorBody["code"].(string)
+		message, _ = errorBody["message"].(string)
+	case string:
+		// Not every operation status models its error as an object: Synapse's
+		// IntegrationRuntimeOperationStatus, for one, types it as a plain message.
+		message = errorBody
 	}
-	code, _ := errorBody["code"].(string)
-	message, _ := errorBody["message"].(string)
 	if code == "" && message == "" {
 		return nil
 	}

--- a/provider/pkg/azure/client_azcore_test.go
+++ b/provider/pkg/azure/client_azcore_test.go
@@ -721,6 +721,18 @@ func TestFailedLongRunningOperation(t *testing.T) {
 		assert.Contains(t, err.Error(), "OperationCanceled")
 	})
 
+	// Not every operation status types its error as an object, e.g. Synapse's
+	// IntegrationRuntimeOperationStatus declares it as a plain string.
+	t.Run("failed status envelope with a string error", func(t *testing.T) {
+		client := newClientWithPreparedResponses(lroResponses(http.StatusOK,
+			`{"status":"Failed","error":"the integration runtime failed to start"}`))
+
+		_, _, err := client.Put(context.Background(), id, map[string]any{"location": "westus2"}, qp, "azure-async-operation")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "the integration runtime failed to start")
+	})
+
 	t.Run("succeeded status envelope", func(t *testing.T) {
 		client := newClientWithPreparedResponses(lroResponses(http.StatusOK, `{"status":"Succeeded"}`))
 
@@ -730,7 +742,7 @@ func TestFailedLongRunningOperation(t *testing.T) {
 	})
 
 	// A resource that reports its own state as failed is not a failed operation: without an `error`
-	// object there is nothing to report and the resource was created successfully.
+	// there is nothing to report and the resource was created successfully.
 	t.Run("resource whose own status is failed", func(t *testing.T) {
 		body := `{"id":"` + id + `","name":"sa","status":"Failed","properties":{"provisioningState":"Succeeded"}}`
 		client := newClientWithPreparedResponses(lroResponses(http.StatusOK, body))

--- a/provider/pkg/azure/client_azcore_test.go
+++ b/provider/pkg/azure/client_azcore_test.go
@@ -671,6 +671,77 @@ func TestCanCreate_Responses(t *testing.T) {
 	})
 }
 
+// TestFailedLongRunningOperation covers issue #4484: Azure answers the PUT with a 202 that only
+// carries a Location header, and the poll of that location reports the operation as failed in a 200
+// response. azcore's Location poller reads the state off the HTTP status code, so without an
+// explicit check the failure is handed back as the resource's outputs and the create looks like it
+// succeeded.
+func TestFailedLongRunningOperation(t *testing.T) {
+	const location = "https://management.azure.com/subscriptions/123/providers/Microsoft.Storage/locations/westus2/asyncoperations/abc?api-version=2024-01-01"
+	qp := map[string]any{"api-version": "2024-01-01"}
+	id := "/subscriptions/123/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa"
+
+	putURL, err := url.Parse("https://management.azure.com" + id + "?api-version=2024-01-01")
+	require.NoError(t, err)
+
+	lroResponses := func(pollStatus int, pollBody string) []*http.Response {
+		return []*http.Response{
+			{
+				StatusCode: http.StatusAccepted,
+				Header:     http.Header{"Location": []string{location}},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    &http.Request{Method: http.MethodPut, URL: putURL},
+			},
+			{
+				StatusCode: pollStatus,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(pollBody)),
+			},
+		}
+	}
+
+	t.Run("failed status envelope", func(t *testing.T) {
+		client := newClientWithPreparedResponses(lroResponses(http.StatusOK,
+			`{"status":"Failed","error":{"code":"NetworkAclsValidationFailure","message":"Validation of network acls failure"}}`))
+
+		_, _, err := client.Put(context.Background(), id, map[string]any{"location": "westus2"}, qp, "azure-async-operation")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NetworkAclsValidationFailure")
+		assert.Contains(t, err.Error(), "Validation of network acls failure")
+	})
+
+	t.Run("canceled status envelope", func(t *testing.T) {
+		client := newClientWithPreparedResponses(lroResponses(http.StatusOK,
+			`{"status":"Canceled","error":{"code":"OperationCanceled","message":"The operation was canceled"}}`))
+
+		_, _, err := client.Put(context.Background(), id, map[string]any{"location": "westus2"}, qp, "azure-async-operation")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OperationCanceled")
+	})
+
+	t.Run("succeeded status envelope", func(t *testing.T) {
+		client := newClientWithPreparedResponses(lroResponses(http.StatusOK, `{"status":"Succeeded"}`))
+
+		_, _, err := client.Put(context.Background(), id, map[string]any{"location": "westus2"}, qp, "azure-async-operation")
+
+		require.NoError(t, err)
+	})
+
+	// A resource that reports its own state as failed is not a failed operation: without an `error`
+	// object there is nothing to report and the resource was created successfully.
+	t.Run("resource whose own status is failed", func(t *testing.T) {
+		body := `{"id":"` + id + `","name":"sa","status":"Failed","properties":{"provisioningState":"Succeeded"}}`
+		client := newClientWithPreparedResponses(lroResponses(http.StatusOK, body))
+
+		outputs, _, err := client.Put(context.Background(), id, map[string]any{"location": "westus2"}, qp, "azure-async-operation")
+
+		require.NoError(t, err)
+		assert.Equal(t, "sa", outputs["name"])
+	})
+}
+
 // Implements azcore's policy.Transporter by returning the given responses in order.
 type fakeTransporter struct {
 	requests  []*http.Request

--- a/provider/pkg/azure/client_azcore_test.go
+++ b/provider/pkg/azure/client_azcore_test.go
@@ -490,6 +490,27 @@ func TestErrorStatusCodes(t *testing.T) {
 		require.Equal(t, "BadRequest", err.(*PulumiAzcoreResponseError).ErrorCode)
 	})
 
+	// A poll that reports the deletion as failed in a 200 response: azcore's Location poller reads
+	// the terminal state off the HTTP status code, so without an explicit check the resource would
+	// be reported as deleted while it is still there.
+	t.Run("DELETE polling failure reported as a status envelope", func(t *testing.T) {
+		client := newClientWithPreparedResponses([]*http.Response{
+			{
+				StatusCode: 202,
+				Header:     http.Header{"Location": []string{"https://management.azure.com/operation"}},
+				Body:       io.NopCloser(strings.NewReader(`{"status": "InProgress"}`)),
+			},
+			{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"Failed","error":{"code":"InUseSubnetCannotBeDeleted","message":"Subnet is in use"}}`)),
+			},
+		})
+		err := client.Delete(context.Background(), "/subscriptions/123/rg/rg", "2022-09-01", "the actual value doesn't matter!", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "InUseSubnetCannotBeDeleted")
+		assert.Contains(t, err.Error(), "Subnet is in use")
+	})
+
 	t.Run("DELETE polling failure when asyncStyle is given", func(t *testing.T) {
 		client := newClientWithPreparedResponses([]*http.Response{
 			{

--- a/provider/pkg/provider/provider_e2e_test.go
+++ b/provider/pkg/provider/provider_e2e_test.go
@@ -205,6 +205,23 @@ func TestWebAppBackupConfiguration(t *testing.T) {
 	assert.Zero(t, upSummary[apitype.OpUpdate], "expected no updates on a repeat up")
 }
 
+// TestStorageAccountNetworkAclsFailure guards against issue #4484: Azure accepts the storage
+// account's PUT with a 202, then fails the long-running operation with NetworkAclsValidationFailure
+// and rolls the account back. The user must see that error, not a compound "resource created but
+// read failed 404 StorageAccountNotFound" one that hides it.
+func TestStorageAccountNetworkAclsFailure(t *testing.T) {
+	t.Parallel()
+	pt := newPulumiTest(t, "storage-account-network-acls-failure")
+	defer func() {
+		pt.Destroy(t)
+	}()
+
+	_, err := pt.UpErr(t)
+	require.Error(t, err, "expected the storage account creation to fail")
+	assert.Contains(t, err.Error(), "NetworkAclsValidationFailure")
+	assert.NotContains(t, err.Error(), "resource created but read failed")
+}
+
 func TestAutonaming(t *testing.T) {
 	t.Parallel()
 	pt := newPulumiTest(t, "autonaming", opttest.Env("PULUMI_EXPERIMENTAL", "1"))

--- a/provider/pkg/provider/test-programs/storage-account-network-acls-failure/Pulumi.yaml
+++ b/provider/pkg/provider/test-programs/storage-account-network-acls-failure/Pulumi.yaml
@@ -1,0 +1,38 @@
+name: storageaclsfailure
+runtime: yaml
+description: |
+  A storage account whose network ACLs reference a subnet without a Microsoft.Storage service
+  endpoint. Azure accepts the PUT with a 202, fails the long-running operation and rolls the
+  account back, so the creation is expected to fail. See issue #4484.
+resources:
+  rg:
+    type: azure-native:resources:ResourceGroup
+
+  vnet:
+    type: azure-native:network:VirtualNetwork
+    properties:
+      resourceGroupName: ${rg.name}
+      addressSpace:
+        addressPrefixes:
+          - 10.0.0.0/16
+
+  subnet:
+    type: azure-native:network:Subnet
+    properties:
+      resourceGroupName: ${rg.name}
+      virtualNetworkName: ${vnet.name}
+      addressPrefix: 10.0.1.0/24
+      # Deliberately no Microsoft.Storage service endpoint, which is what makes the account fail.
+
+  store:
+    type: azure-native:storage:StorageAccount
+    properties:
+      resourceGroupName: ${rg.name}
+      kind: StorageV2
+      sku:
+        name: Standard_LRS
+      networkRuleSet:
+        defaultAction: Deny
+        bypass: AzureServices
+        virtualNetworkRules:
+          - virtualNetworkResourceId: ${subnet.id}


### PR DESCRIPTION
Fixes #4484.

Creating a storage account whose `networkRuleSet` references a subnet without a `Microsoft.Storage` service endpoint fails in Azure, but the provider reported it in one of two unhelpful ways depending on how Azure delivered the failure. Two independent causes.

### 1. A failed long-running operation reported as success

Storage's `202` carries a `Location` header and no `Azure-AsyncOperation` header, and azcore's Location poller derives the operation's terminal state from the HTTP status code alone. So when a poll answers `200` with `{"status":"Failed","error":{...}}`, the failure was taken for a success: the envelope was handed back as the resource's outputs, the create "succeeded", and the only thing the user saw was the generic warning from the subsequent read of a resource Azure had already rolled back:

```
warning: Failed to read resource after Create. Please report this issue.
```

A completed poll's body is now checked for a terminal failure status and turned into an error naming the Azure code and message. This covers deletes too, where the same swallow reported a resource that is still in Azure as deleted. The watchlist delete path is left alone — it already races the poll against a GET that confirms the resource is gone, precisely because that API misreports its deletions (#4816).

A failure envelope must carry an `error`, either as an object or (Synapse's integration runtime operation statuses, Elastic's `MonitoredSubscription`) as a plain string. Requiring it is what keeps a resource whose *own* state is reported as failed from being mistaken for a failed operation: of the spec definitions with a `Failed`-capable status and no `error` alongside it, nearly all are resources rather than operations — job runs, restores, compilations.

### 2. Misleading error when the poll does fail properly

When the poll instead ends in a `400`, the error arrived wrapped in one that contradicted it:

```
* resource created but read failed Status=404 Code="StorageAccountNotFound" ...:
  Status=400 Code="NetworkAclsValidationFailure" Message="... do not have ServiceEndpoints for
  Microsoft.Storage resources configured ..."
```

`HandleErrorWithCheckpoint` already returns the original failure directly when the checkpoint read confirms a 404, but `IsNotFound`'s allowlist didn't include `StorageAccountNotFound`, so this fell through to the compound message — and checkpointed a resource that doesn't exist into state, which then showed up as an *update* on the next `pulumi up`.

### Testing

Unit tests cover both fixes and each was confirmed to fail without its fix. The new e2e test deploys the reported program against Azure and asserts the `NetworkAclsValidationFailure` reaches the user. Run live to check the new checks don't disturb healthy long-running operations: `TestStorageBlob`, `TestSubResources`, `TestWebAppBackupConfiguration`, `TestServiceBusNetworkRuleset` and `TestSecurityInsightsWatchlistDelete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)