### PR TITLE
Fix #4477: rewrite oneOf type tokens when parameterizing a package

### DIFF
--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -186,22 +186,24 @@ func generateNewPackageName(unparameterizedPackageName, targetModule, targetApiV
 	return strings.Join([]string{unparameterizedPackageName, targetModule, targetApiVersion}, parameterizedNameSeparator)
 }
 
-// updateRefs updates all `$ref` pointers in the serialized schema to use the new package name, e.g., from `"$ref":
-// "#/types/azure-native:..."` to `"$ref": "#/types/azure-native_resources_20240101:..."`.
+// updateRefs updates all type references in the serialized schema or metadata to use the new package name, e.g., from
+// `"#/types/azure-native:resources/v20240101:Foo"` to `"#/types/azure-native_resources_v20240101:resources:Foo"`.
+// References appear as `$ref` values but also, in the metadata, as bare strings in `oneOf` arrays, so we match the
+// reference itself rather than the `$ref` key. See #4477.
 func updateRefs(serialized []byte, newPackageName, module, apiVersion string) []byte {
-	oldRefPrefix := fmt.Sprintf(`"$ref":"#/types/azure-native:%s/%s`, module, apiVersion)
-	newRefPrefix := fmt.Sprintf(`"$ref": "#/types/%s:%s`, newPackageName, module)
+	oldRefPrefix := fmt.Sprintf(`"#/types/azure-native:%s/%s`, module, apiVersion)
+	newRefPrefix := fmt.Sprintf(`"#/types/%s:%s`, newPackageName, module)
 	newSchema := bytes.ReplaceAll(serialized, []byte(oldRefPrefix), []byte(newRefPrefix))
 
 	// update common types refs as well
-	oldCommonRefPrefix := `"$ref":"#/types/azure-native:commontypes`
-	newCommonRefPrefix := fmt.Sprintf(`"$ref": "#/types/%s:commontypes`, newPackageName)
+	oldCommonRefPrefix := `"#/types/azure-native:commontypes`
+	newCommonRefPrefix := fmt.Sprintf(`"#/types/%s:commontypes`, newPackageName)
 	newSchemaWithModifiedCommonTypes := bytes.ReplaceAll(newSchema, []byte(oldCommonRefPrefix), []byte(newCommonRefPrefix))
 	return newSchemaWithModifiedCommonTypes
 }
 
-// updateMetadataRefs updates all `$ref` pointers in the metadata to use the new package name.
-// This implementation uses a JSON round-trip to update the `$ref`'s via a global string-replacement. Not elegant, but effective.
+// updateMetadataRefs updates all type references in the metadata to use the new package name.
+// This implementation uses a JSON round-trip to update the references via a global string-replacement. Not elegant, but effective.
 func updateMetadataRefs(metadata *resources.APIMetadata, newPackageName, module, apiVersion string) (*resources.APIMetadata, error) {
 	m, err := json.Marshal(metadata)
 	if err != nil {

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -343,6 +343,49 @@ func TestUpdateMetadataRefs(t *testing.T) {
 		assert.Equal(t, "#/types/azure-native_storage_v20240101:storage:StorageAccount", prop.Properties["prop1"].Ref)
 	})
 
+	// oneOf entries are bare strings rather than $ref objects, so they need matching on the reference itself. When
+	// they were left stale, the runtime failed to resolve the union's members and sent the SDK shape to Azure
+	// verbatim, without un-flattening nested properties. See #4477.
+	t.Run("Updates refs in oneOf unions", func(t *testing.T) {
+		t.Parallel()
+		metadata := &resources.APIMetadata{
+			Types: resources.GoMap[resources.AzureAPIType]{
+				"type1": {
+					Properties: map[string]resources.AzureAPIProperty{
+						"destination": {
+							OneOf: []string{
+								"#/types/azure-native:storage/v20240101:WebHookDestination",
+								"#/types/azure-native:commontypes:EventHubDestination",
+								"#/types/azure-native:other/v20240101:OtherModuleDestination",
+							},
+						},
+						"destinations": {
+							Type: "array",
+							Items: &resources.AzureAPIProperty{
+								OneOf: []string{"#/types/azure-native:storage/v20240101:WebHookDestination"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		updated, err := updateMetadataRefs(metadata, "azure-native_storage_v20240101", "storage", "v20240101")
+		require.NoError(t, err)
+
+		typ, ok, err := updated.Types.Get("type1")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, []string{
+			"#/types/azure-native_storage_v20240101:storage:WebHookDestination",
+			"#/types/azure-native_storage_v20240101:commontypes:EventHubDestination",
+			// A different module isn't part of the parameterized package, so it's left alone.
+			"#/types/azure-native:other/v20240101:OtherModuleDestination",
+		}, typ.Properties["destination"].OneOf)
+		assert.Equal(t, []string{"#/types/azure-native_storage_v20240101:storage:WebHookDestination"},
+			typ.Properties["destinations"].Items.OneOf)
+	})
+
 	t.Run("Updates refs in resources", func(t *testing.T) {
 		t.Parallel()
 		metadata := &resources.APIMetadata{


### PR DESCRIPTION
### Impact

Every union-typed (`oneOf`) property in a **version-pinned package** (`pulumi package add azure-native <module> <version>`) was sent to Azure as the raw SDK shape: no un-flattening of `x-ms-client-flatten` containers, no SDK-to-wire name mapping, no const checks. The unparameterized `azure-native` package was never affected.

Fixes #4477, where this put EventGrid's WebHook destination properties directly on `destination` instead of nesting them under `properties`, and Azure rejected the request.

### Cause

Parameterization renames every type token, and `updateRefs` did that by string-replacing `"$ref":"#/types/azure-native:<module>/<version>` in the serialized schema and metadata. In the metadata, `oneOf` is a `[]string` — bare strings in a JSON array, not `$ref` objects — so union members kept the **old** tokens while the types around them were renamed. At runtime those tokens no longer resolved, `SdkInputsToRequestBody` fell through its union branch, and the value went out verbatim.

The schema side was fine: there `oneOf` holds `$ref` objects, so SDK codegen produced correct unions. The breakage was invisible until the request hit the wire.

Matching on the reference itself instead of the `$ref` key rewrites both forms.

### Verification

- New `TestUpdateMetadataRefs/Updates_refs_in_oneOf_unions`, covering a direct `oneOf`, a `commontypes` member, `items.oneOf`, and a different-module ref that must be left alone. Fails without the fix.
- Live against Azure with the issue's program on `azure-native_eventgrid_v20250401preview`: destination now nests under `properties`, `provisioningState: Succeeded`, and a follow-up `refresh` + `preview --diff` are clean — so the union round-trips on read as well as write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)